### PR TITLE
Add Heart Sutra page with bilingual text and teachings

### DIFF
--- a/public/enso.svg
+++ b/public/enso.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="-40 -40 280 280">
+  <!--
+    Viewbox has 40px padding on every side so the ink-displacement filter
+    and thick stroke never clip when embedded via <img>.
+    Stroke is hardcoded #1c1917 (light-mode ink); the page inverts it for dark mode.
+  -->
+  <defs>
+    <filter id="k" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
+      <feTurbulence type="fractalNoise" baseFrequency="0.04 0.13" numOctaves="5" seed="7" result="n"/>
+      <feDisplacementMap in="SourceGraphic" in2="n" scale="13" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>
+  </defs>
+  <path
+    d="M 62 22 C 38 38, 16 51, 15 97 C 14 145, 49 183, 97 184 C 145 185, 182 149, 184 102 C 186 55, 162 38, 138 22"
+    fill="none"
+    stroke="#1c1917"
+    stroke-width="40"
+    stroke-linecap="round"
+    filter="url(#k)"
+  />
+</svg>

--- a/src/components/Projects.astro
+++ b/src/components/Projects.astro
@@ -37,9 +37,12 @@ const sortedProjects = projects.sort((a: Project, b: Project) => {
 
 		<div class="grid grid-cols-1 md:grid-cols-2 gap-10">
 			{
-				sortedProjects.map((project: Project) => (
+				sortedProjects.map((project: Project) => {
+					const href = project.data.link ?? `/projects/${project.slug}`;
+					const isExternal = href.startsWith('http');
+					return (
 					<article class="group">
-						<a href={`/projects/${project.slug}`} class="block">
+						<a href={href} {...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}>
 							<div class="relative aspect-[16/10] mb-5 overflow-hidden rounded-lg bg-gray-100 dark:bg-gray-800">
 								{project.data.image ? (
 									<Image
@@ -67,7 +70,8 @@ const sortedProjects = projects.sort((a: Project, b: Project) => {
 						<div>
 							<h3 class="text-xl font-semibold text-garden-primary dark:text-garden-dark-primary mb-2 font-ui">
 								<a
-									href={`/projects/${project.slug}`}
+									href={href}
+									{...(isExternal ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
 									class="hover:text-garden-accent dark:hover:text-garden-dark-accent transition-colors"
 								>
 									{project.data.title}
@@ -91,7 +95,8 @@ const sortedProjects = projects.sort((a: Project, b: Project) => {
 							</div>
 						</div>
 					</article>
-				))
+					);
+				})
 			}
 		</div>
 	</div>

--- a/src/content/projects/heart-sutra-bunkobon.mdx
+++ b/src/content/projects/heart-sutra-bunkobon.mdx
@@ -1,0 +1,28 @@
+---
+title: "般若心経 — Heart Sutra Bunkobon"
+description: "A digital bunkobon (Japanese pocket paperback) of the Heart Sutra, with the complete text in Japanese and English, furigana, romaji, and sumi-e illustrations."
+link: "/heart-sutra"
+status: "Completed"
+startDate: 2026-02-23
+tags: ["Design", "Japanese", "Buddhism", "Web"]
+features: [
+  "Animated Enso circle cover with washi-paper aesthetic",
+  "Complete 260-character sutra in Japanese with ruby/furigana",
+  "Toggle controls for hiragana furigana and Hepburn romaji",
+  "Hand-drawn sumi-e SVG illustrations (lotus, torii gate)",
+  "Full English translation and explanations of key concepts",
+  "Dark mode support"
+]
+techStack: [
+  {
+    category: "Frontend",
+    items: ["Astro", "TypeScript", "Tailwind CSS"]
+  },
+  {
+    category: "Design",
+    items: ["SVG", "CSS Animations", "Ruby HTML", "Washi-paper aesthetic"]
+  }
+]
+---
+
+A digital bunkobon (Japanese pocket paperback) of the Heart Sutra (般若心経), built as an Astro page with a washi-paper aesthetic, animated Enso cover, and interactive reading aids.

--- a/src/pages/heart-sutra.astro
+++ b/src/pages/heart-sutra.astro
@@ -19,10 +19,10 @@ import BackButton from '../components/BackButton.astro';
 			<div class="enso-wrapper" aria-hidden="true">
 				<svg class="enso" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
 					<defs>
-						<!-- Subtle displacement gives the stroke a bristle-like organic quality -->
-						<filter id="enso-ink" x="-6%" y="-6%" width="112%" height="112%" color-interpolation-filters="sRGB">
-							<feTurbulence type="fractalNoise" baseFrequency="0.72 0.38" numOctaves="4" seed="7" result="noise"/>
-							<feDisplacementMap in="SourceGraphic" in2="noise" scale="2.8" xChannelSelector="R" yChannelSelector="G"/>
+						<!-- Low baseFrequency = coarse bristle marks; high scale = bold ink distortion -->
+						<filter id="enso-ink" x="-18%" y="-18%" width="136%" height="136%" color-interpolation-filters="sRGB">
+							<feTurbulence type="fractalNoise" baseFrequency="0.04 0.13" numOctaves="5" seed="7" result="noise"/>
+							<feDisplacementMap in="SourceGraphic" in2="noise" scale="13" xChannelSelector="R" yChannelSelector="G"/>
 						</filter>
 					</defs>
 					<!--
@@ -43,7 +43,7 @@ import BackButton from '../components/BackButton.astro';
 						   C 186 55, 156 15, 109 17"
 						fill="none"
 						stroke="currentColor"
-						stroke-width="26"
+						stroke-width="44"
 						stroke-linecap="round"
 						filter="url(#enso-ink)"
 					/>

--- a/src/pages/heart-sutra.astro
+++ b/src/pages/heart-sutra.astro
@@ -1,0 +1,902 @@
+---
+import Layout from '../layouts/Layout.astro';
+import BackButton from '../components/BackButton.astro';
+---
+
+<Layout
+	title="般若心経 — The Heart Sutra | The Void"
+	description="A bunkobon pocket guide to the Heart Sutra (般若心経). Complete text in Japanese and English with explanations of its key teachings on emptiness, non-duality, and liberation."
+>
+	<div class="heart-sutra-page">
+
+		<!-- ============================================================
+		     BOOK COVER
+		     ============================================================ -->
+		<section class="book-cover">
+			<a href="/" class="back-link" aria-label="Back to home">← back</a>
+
+			<!-- Enso Circle (animated brushstroke) -->
+			<div class="enso-wrapper" aria-hidden="true">
+				<svg class="enso" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+					<path
+						class="enso-circle"
+						d="M 100 22
+						   C 144 22, 178 57, 178 100
+						   C 178 143, 144 178, 100 178
+						   C 56 178, 22 143, 22 100
+						   C 22 60, 50 27, 94 22"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="9"
+						stroke-linecap="round"
+					/>
+				</svg>
+			</div>
+
+			<div class="cover-title">
+				<div class="kanji-title" lang="ja">般若心経</div>
+				<div class="cover-divider"></div>
+				<div class="cover-subtitle">Hannya Shingyō</div>
+				<div class="cover-tagline">知恵の心 &mdash; The Heart of Wisdom</div>
+			</div>
+		</section>
+
+		<!-- ============================================================
+		     BOOK BODY
+		     ============================================================ -->
+		<div class="book-body">
+
+			<!-- ── Title Page ─────────────────────────────────────────── -->
+			<div class="book-page title-page">
+				<span class="page-number" aria-hidden="true">i</span>
+				<div class="title-page-content">
+					<div class="title-kanji" lang="ja">般若心経</div>
+					<h1 class="title-english">The Heart Sutra</h1>
+					<p class="title-tagline">A Pocket Guide to the Essence of Wisdom</p>
+				</div>
+			</div>
+
+			<!-- ── Introduction ───────────────────────────────────────── -->
+			<div class="book-page">
+				<span class="page-number" aria-hidden="true">3</span>
+				<div class="chapter-header">
+					<span class="chapter-label" lang="ja">序文</span>
+					<h2 class="chapter-title">Introduction</h2>
+				</div>
+				<div class="book-text">
+					<p>
+						The <em>Prajnaparamita Hridaya Sutra</em>, commonly known as the Heart
+						Sutra, is one of the most famous and beloved texts in Mahayana Buddhism.
+						Though it is only 260 characters long in its Chinese translation, it
+						encapsulates the profound heart of Buddhist wisdom.
+					</p>
+					<p>
+						The sutra is a teaching given by the Bodhisattva Avalokiteshvara to
+						Shariputra, a senior disciple of the Buddha. Its core message is the
+						teaching of <em>Shunyata</em>, or &ldquo;emptiness.&rdquo; This is not a
+						nihilistic &ldquo;nothingness,&rdquo; but a revelation that all things,
+						concepts, and phenomena lack a fixed, independent, and permanent self.
+						They are interconnected and ever-changing.
+					</p>
+					<p>
+						This short book presents the sutra in Japanese and English, followed by
+						brief explanations of its key concepts to help you on your journey of
+						understanding.
+					</p>
+				</div>
+			</div>
+
+			<!-- ── Japanese Sutra ─────────────────────────────────────── -->
+			<div class="book-page sutra-page">
+				<span class="page-number" aria-hidden="true">5</span>
+				<div class="chapter-header">
+					<span class="chapter-label" lang="ja">経文</span>
+					<h2 class="chapter-title" lang="ja">摩訶般若波羅蜜多心経</h2>
+				</div>
+
+				<div class="japanese-sutra">
+					<p class="sutra-text" lang="ja">
+						観自在菩薩行深般若波羅蜜多時照見五蘊皆空度一切苦厄舎利子色不異空空不異色色即是空空即是色受想行識亦復如是舎利子是諸法空相不生不滅不垢不浄不増不減是故空中無色無受想行識無眼耳鼻舌身意無色声香味触法無眼界乃至無意識界無無明亦無無明尽乃至無老死亦無老死尽無苦集滅道無智亦無得以無所得故菩提薩埵依般若波羅蜜多故心無罣礙無罣礙故無有恐怖遠離一切顛倒夢想究竟涅槃三世諸仏依般若波羅蜜多故得阿耨多羅三藐三菩提故知般若波羅蜜多是大神呪是大明呪是無上呪是無等等呪能除一切苦真実不虚故説般若波羅蜜多呪即説呪曰
+					</p>
+					<p class="mantra-jp" lang="ja">羯諦　羯諦　波羅羯諦　波羅僧羯諦　菩提　薩婆訶</p>
+					<p class="sutra-end" lang="ja">般若心経</p>
+				</div>
+			</div>
+
+			<!-- ── English Translation ────────────────────────────────── -->
+			<div class="book-page">
+				<span class="page-number" aria-hidden="true">6</span>
+				<div class="chapter-header">
+					<span class="chapter-label" lang="ja">英訳</span>
+					<h2 class="chapter-title">The Heart Sutra</h2>
+					<p class="chapter-subtitle">English Translation</p>
+				</div>
+				<div class="book-text">
+					<p>
+						When the Bodhisattva Avalokiteshvara was practicing the profound
+						Perfection of Wisdom, he perceived that all five aggregates are empty and
+						was saved from all suffering and distress.
+					</p>
+					<p>
+						&ldquo;Shariputra, form does not differ from emptiness, emptiness does
+						not differ from form. That which is form is emptiness, that which is
+						emptiness is form. The same is true of feelings, perceptions, impulses,
+						and consciousness.
+					</p>
+					<p>
+						Shariputra, all dharmas are marked with emptiness; they do not appear or
+						disappear, are not tainted or pure, do not increase or decrease.
+					</p>
+					<p>
+						Therefore, in emptiness there is no form, no feeling, no perception, no
+						impulse, no consciousness. No eye, no ear, no nose, no tongue, no body,
+						no mind; no color, no sound, no smell, no taste, no touch, no object of
+						mind; no realm of eyes and so forth until no realm of mind consciousness.
+						No ignorance and also no extinction of it, and so forth until no old age
+						and death and also no extinction of them. No suffering, no origination,
+						no stopping, no path, no cognition, also no attainment with nothing to
+						attain.
+					</p>
+					<p>
+						The Bodhisattva depends on Prajnaparamita and the mind is no hindrance;
+						without any hindrance no fears exist. Far apart from every perverted view
+						one dwells in Nirvana.
+					</p>
+					<p>
+						All Buddhas in the past, present, and future depend on Prajnaparamita and
+						attain Anuttara Samyak Sambodhi.
+					</p>
+					<p>
+						Therefore, know that Prajnaparamita is the great transcendent mantra, is
+						the great bright mantra, is the utmost mantra, is the supreme mantra,
+						which is able to relieve all suffering and is true, not false. So proclaim
+						the Prajnaparamita mantra, proclaim the mantra which says:
+					</p>
+					<p class="mantra-english">
+						<em>Gate gate p&#257;ragate p&#257;rasamgate bodhi sv&#257;h&#257;.&rdquo;</em>
+					</p>
+				</div>
+			</div>
+
+			<!-- ── Explanations ───────────────────────────────────────── -->
+			<div class="book-page explanations-page">
+				<span class="page-number" aria-hidden="true">9</span>
+				<div class="chapter-header">
+					<span class="chapter-label" lang="ja">解説</span>
+					<h2 class="chapter-title">Explanations</h2>
+				</div>
+
+				<!-- Lotus Illustration -->
+				<figure class="book-illustration" aria-label="Sumi-e lotus flower illustration">
+					<svg
+						class="sumi-e"
+						viewBox="0 0 240 200"
+						xmlns="http://www.w3.org/2000/svg"
+						aria-hidden="true"
+					>
+						<!-- Roots fading into emptiness below water -->
+						<path d="M 120 132 L 114 155 Q 111 168 109 180" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="3,5" opacity="0.2"/>
+						<path d="M 120 132 L 126 155 Q 129 168 131 180" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="3,5" opacity="0.2"/>
+						<path d="M 118 142 L 106 162 Q 102 174 100 184" fill="none" stroke="currentColor" stroke-width="0.8" stroke-dasharray="2,6" opacity="0.12"/>
+						<!-- Water surface -->
+						<path d="M 8 132 Q 60 125, 120 132 Q 180 139, 232 132" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.5"/>
+						<!-- Stem -->
+						<path d="M 120 132 Q 119 112, 120 96" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+						<!-- Leaves -->
+						<path d="M 118 116 Q 88 108, 70 122" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+						<path d="M 122 116 Q 152 108, 170 122" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+						<!-- Center petal -->
+						<path d="M 120 30 Q 113 54, 114 74 Q 116 88, 120 96 Q 124 88, 126 74 Q 127 54, 120 30" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+						<!-- Left inner petal -->
+						<path d="M 104 40 Q 98 60, 100 78 Q 104 91, 112 96 Q 112 80, 108 62 Q 104 46, 104 40" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+						<!-- Right inner petal -->
+						<path d="M 136 40 Q 142 60, 140 78 Q 136 91, 128 96 Q 128 80, 132 62 Q 136 46, 136 40" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+						<!-- Left outer petal -->
+						<path d="M 82 58 Q 84 78, 90 92 Q 98 102, 110 103 Q 102 86, 94 72 Q 87 60, 82 58" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+						<!-- Right outer petal -->
+						<path d="M 158 58 Q 156 78, 150 92 Q 142 102, 130 103 Q 138 86, 146 72 Q 153 60, 158 58" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+					</svg>
+					<figcaption class="illustration-caption" lang="ja">形は空に溶ける</figcaption>
+				</figure>
+
+				<!-- Explanation 1 -->
+				<article class="explanation">
+					<div class="explanation-header">
+						<span class="explanation-number" aria-hidden="true" lang="ja">一</span>
+						<div>
+							<h3 class="explanation-title">Form is Emptiness, Emptiness is Form</h3>
+							<p class="explanation-kanji" lang="ja">色即是空、空即是色</p>
+							<p class="explanation-romaji">Shiki soku ze kū, kū soku ze shiki</p>
+						</div>
+					</div>
+					<div class="book-text">
+						<p>
+							This is the sutra&rsquo;s most famous and paradoxical statement.
+							&ldquo;Form&rdquo; refers to the physical world, our bodies, and material
+							objects. The sutra asserts that these forms have no permanent, inherent
+							existence. They are &ldquo;empty&rdquo; because they are constantly
+							changing and dependent on other conditions to exist.
+						</p>
+						<p>
+							A wave is distinct, yet it is just water. The wave is &ldquo;empty&rdquo;
+							of a separate self; it is the water. Conversely, this
+							&ldquo;emptiness&rdquo; is not apart from the physical world; it
+							manifests as form.
+						</p>
+					</div>
+				</article>
+
+				<!-- Explanation 2 -->
+				<article class="explanation">
+					<div class="explanation-header">
+						<span class="explanation-number" aria-hidden="true" lang="ja">二</span>
+						<div>
+							<h3 class="explanation-title">The Five Aggregates are Empty</h3>
+							<p class="explanation-kanji" lang="ja">五蘊皆空</p>
+							<p class="explanation-romaji">Goun kai kū</p>
+						</div>
+					</div>
+					<div class="book-text">
+						<p>
+							The Buddha taught that what we call a &ldquo;self&rdquo; is just a
+							temporary combination of five parts, or aggregates:
+						</p>
+						<ol class="aggregate-list">
+							<li><strong>Form</strong> &mdash; The physical body.</li>
+							<li><strong>Feeling</strong> &mdash; Sensations of pleasant, unpleasant, or neutral.</li>
+							<li><strong>Perception</strong> &mdash; Recognizing and labeling things.</li>
+							<li><strong>Mental Formations</strong> &mdash; Thoughts, volitions, and emotions.</li>
+							<li><strong>Consciousness</strong> &mdash; Awareness itself.</li>
+						</ol>
+						<p>
+							Avalokiteshvara sees that none of these parts constitute a permanent
+							&ldquo;I&rdquo;. When we realize our &ldquo;self&rdquo; is empty, we are
+							freed from the suffering that comes from clinging to it.
+						</p>
+					</div>
+				</article>
+
+				<!-- Torii Gate Illustration -->
+				<figure class="book-illustration" aria-label="Sumi-e torii gate illustration">
+					<svg
+						class="sumi-e"
+						viewBox="0 0 240 200"
+						xmlns="http://www.w3.org/2000/svg"
+						aria-hidden="true"
+					>
+						<!-- Mist / cliff base -->
+						<path d="M 0 182 Q 120 174, 240 182 L 240 200 L 0 200 Z" fill="currentColor" opacity="0.06"/>
+						<path d="M 0 190 Q 120 183, 240 190 L 240 200 L 0 200 Z" fill="currentColor" opacity="0.05"/>
+						<!-- Left pillar -->
+						<line x1="74" y1="66" x2="74" y2="182" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+						<!-- Right pillar -->
+						<line x1="166" y1="66" x2="166" y2="182" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+						<!-- Nuki (second horizontal beam) -->
+						<line x1="58" y1="90" x2="182" y2="90" stroke="currentColor" stroke-width="4.5" stroke-linecap="round"/>
+						<!-- Shimagi (beam directly under kasagi) -->
+						<line x1="44" y1="69" x2="196" y2="69" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
+						<!-- Kasagi (top curved beam) -->
+						<path d="M 18 57 Q 120 30, 222 57" fill="none" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+						<!-- Mist wisps around pillars -->
+						<path d="M 0 158 Q 38 152, 65 158" fill="none" stroke="currentColor" stroke-width="1" opacity="0.18"/>
+						<path d="M 178 160 Q 205 154, 240 160" fill="none" stroke="currentColor" stroke-width="1" opacity="0.18"/>
+						<path d="M 0 170 Q 50 164, 70 170" fill="none" stroke="currentColor" stroke-width="1" opacity="0.12"/>
+						<path d="M 175 172 Q 205 166, 240 172" fill="none" stroke="currentColor" stroke-width="1" opacity="0.12"/>
+					</svg>
+					<figcaption class="illustration-caption" lang="ja">彼岸への門</figcaption>
+				</figure>
+
+				<!-- Explanation 3 -->
+				<article class="explanation">
+					<div class="explanation-header">
+						<span class="explanation-number" aria-hidden="true" lang="ja">三</span>
+						<div>
+							<h3 class="explanation-title">The Great Mantra</h3>
+							<p class="explanation-kanji" lang="ja">羯諦羯諦…</p>
+							<p class="explanation-romaji">Gyatei gyatei…</p>
+						</div>
+					</div>
+					<div class="book-text">
+						<p>
+							The sutra concludes with a powerful mantra, a chant that encapsulates
+							the energy of the teaching. It is often left untranslated to preserve
+							its power, but its meaning is approximately:
+						</p>
+						<blockquote>
+							&ldquo;Gone, gone, gone beyond, gone altogether beyond, O awakening,
+							hail!&rdquo;
+						</blockquote>
+						<ul class="mantra-breakdown">
+							<li><strong>Gate</strong> &mdash; Gone from the shore of suffering and ignorance.</li>
+							<li><strong>Paragate</strong> &mdash; Gone to the other shore of enlightenment.</li>
+							<li><strong>Parasamgate</strong> &mdash; Gone completely, together with all beings.</li>
+							<li><strong>Bodhi</strong> &mdash; Awakening.</li>
+							<li><strong>Sv&#257;h&#257;</strong> &mdash; An expression of delight, like &ldquo;So be it!&rdquo; or &ldquo;Hallelujah!&rdquo;</li>
+						</ul>
+						<p>
+							Reciting the mantra is a practice to help us let go of our conceptual
+							thinking and cross over from the world of suffering to the shore of
+							liberation.
+						</p>
+					</div>
+				</article>
+
+			</div><!-- /explanations-page -->
+
+		</div><!-- /book-body -->
+
+		<!-- ============================================================
+		     BACK COVER
+		     ============================================================ -->
+		<section class="back-cover" aria-label="Back cover">
+			<div class="back-cover-enso" aria-hidden="true">
+				<svg viewBox="0 0 80 80" xmlns="http://www.w3.org/2000/svg">
+					<path
+						d="M 40 8 C 58 8, 72 22, 72 40 C 72 58, 58 72, 40 72 C 22 72, 8 58, 8 40 C 8 24, 20 10, 37 8"
+						fill="none"
+						stroke="currentColor"
+						stroke-width="5"
+						stroke-linecap="round"
+						opacity="0.35"
+					/>
+				</svg>
+			</div>
+			<div class="back-cover-content">
+				<p class="back-cover-blurb">
+					A timeless guide to the essence of Buddhist wisdom.
+				</p>
+				<p class="back-cover-description">
+					This pocket-sized edition contains the complete text of the Heart Sutra in
+					Japanese and English, along with concise explanations of its most profound
+					teachings on emptiness, non-duality, and liberation.
+				</p>
+				<p class="back-cover-tagline">
+					A perfect companion for meditation and daily reflection.
+				</p>
+				<div class="back-cover-rule" aria-hidden="true"></div>
+				<p class="back-cover-kanji" lang="ja">般若心経</p>
+			</div>
+		</section>
+
+	</div><!-- /heart-sutra-page -->
+</Layout>
+
+<style>
+	/* =====================================================================
+	   CSS VARIABLES — washi-paper palette
+	   ===================================================================== */
+	:root {
+		--washi:        #f4efe5;
+		--washi-deep:   #ece6d9;
+		--ink:          #1c1917;
+		--ink-mid:      rgba(28, 25, 23, 0.55);
+		--ink-faint:    rgba(28, 25, 23, 0.18);
+		--enso-size:    min(300px, 75vw);
+	}
+
+	:global(.dark) {
+		--washi:        #1a1815;
+		--washi-deep:   #141210;
+		--ink:          #e8e2d6;
+		--ink-mid:      rgba(232, 226, 214, 0.55);
+		--ink-faint:    rgba(232, 226, 214, 0.15);
+	}
+
+	/* =====================================================================
+	   FULL-BLEED WRAPPER — cancels Layout padding
+	   ===================================================================== */
+	.heart-sutra-page {
+		margin-top:    -2rem;
+		margin-bottom: -2rem;
+		margin-left:   -1.5rem;
+		margin-right:  -1.5rem;
+	}
+
+	@media (min-width: 768px) {
+		.heart-sutra-page {
+			margin-left:  -3rem;
+			margin-right: -3rem;
+		}
+	}
+
+	@media (min-width: 1024px) {
+		.heart-sutra-page {
+			margin-left:  -4rem;
+			margin-right: -4rem;
+		}
+	}
+
+	/* =====================================================================
+	   COVER
+	   ===================================================================== */
+	.book-cover {
+		background-color: var(--washi);
+		color: var(--ink);
+		min-height: 100svh;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 5rem 2rem 4rem;
+		position: relative;
+		overflow: hidden;
+	}
+
+	/* subtle ruled-paper lines */
+	.book-cover::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+		background-image: repeating-linear-gradient(
+			0deg,
+			transparent,
+			transparent 31px,
+			rgba(0, 0, 0, 0.025) 31px,
+			rgba(0, 0, 0, 0.025) 32px
+		);
+		pointer-events: none;
+	}
+
+	:global(.dark) .book-cover::before {
+		background-image: repeating-linear-gradient(
+			0deg,
+			transparent,
+			transparent 31px,
+			rgba(255, 255, 255, 0.025) 31px,
+			rgba(255, 255, 255, 0.025) 32px
+		);
+	}
+
+	/* back link */
+	.back-link {
+		position: absolute;
+		top: 1.5rem;
+		left: 1.75rem;
+		font-family: var(--font-sans), 'Inter', system-ui, sans-serif;
+		font-size: 0.8rem;
+		letter-spacing: 0.08em;
+		color: var(--ink-mid);
+		text-decoration: none;
+		transition: color 0.2s ease;
+	}
+
+	.back-link:hover {
+		color: var(--ink);
+	}
+
+	/* enso SVG */
+	.enso-wrapper {
+		margin-bottom: 3rem;
+	}
+
+	.enso {
+		width: var(--enso-size);
+		height: var(--enso-size);
+		color: var(--ink);
+		display: block;
+	}
+
+	.enso-circle {
+		stroke-dasharray: 680;
+		stroke-dashoffset: 680;
+		animation: draw-enso 2.6s cubic-bezier(0.4, 0, 0.2, 1) forwards 0.5s;
+	}
+
+	@keyframes draw-enso {
+		to { stroke-dashoffset: 0; }
+	}
+
+	/* cover typography */
+	.cover-title {
+		text-align: center;
+	}
+
+	.kanji-title {
+		font-family: var(--font-display), 'Cormorant Garamond', Georgia, serif;
+		font-size: clamp(2.5rem, 9vw, 5.5rem);
+		font-weight: 400;
+		letter-spacing: 0.25em;
+		color: var(--ink);
+		margin-bottom: 1.25rem;
+		line-height: 1;
+	}
+
+	.cover-divider {
+		width: 3.5rem;
+		height: 1px;
+		background-color: var(--ink-mid);
+		margin: 0 auto 1.25rem;
+	}
+
+	.cover-subtitle {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.75rem;
+		letter-spacing: 0.45em;
+		text-transform: uppercase;
+		color: var(--ink-mid);
+		margin-bottom: 0.75rem;
+	}
+
+	.cover-tagline {
+		font-family: var(--font-display), 'Cormorant Garamond', Georgia, serif;
+		font-size: clamp(1rem, 3vw, 1.6rem);
+		font-style: italic;
+		color: var(--ink-mid);
+		letter-spacing: 0.04em;
+	}
+
+	/* =====================================================================
+	   BOOK BODY
+	   ===================================================================== */
+	.book-body {
+		background-color: var(--washi);
+		color: var(--ink);
+	}
+
+	.book-page {
+		max-width: 640px;
+		margin: 0 auto;
+		padding: 5rem 2.5rem 4.5rem;
+		border-bottom: 1px solid var(--ink-faint);
+		position: relative;
+	}
+
+	.page-number {
+		position: absolute;
+		top: 1.75rem;
+		right: 2.5rem;
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.7rem;
+		letter-spacing: 0.2em;
+		color: var(--ink-mid);
+		user-select: none;
+	}
+
+	/* =====================================================================
+	   CHAPTER HEADERS
+	   ===================================================================== */
+	.chapter-header {
+		margin-bottom: 2.75rem;
+		padding-bottom: 1.5rem;
+		border-bottom: 1px solid var(--ink-faint);
+	}
+
+	.chapter-label {
+		display: block;
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.65rem;
+		letter-spacing: 0.5em;
+		text-transform: uppercase;
+		color: var(--ink-mid);
+		margin-bottom: 0.6rem;
+	}
+
+	.chapter-title {
+		font-family: var(--font-display), 'Cormorant Garamond', Georgia, serif;
+		font-size: clamp(1.8rem, 4vw, 2.6rem);
+		font-weight: 400;
+		font-style: italic;
+		color: var(--ink);
+		margin: 0 0 0.2rem;
+		line-height: 1.2;
+	}
+
+	.chapter-subtitle {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.8rem;
+		letter-spacing: 0.2em;
+		color: var(--ink-mid);
+		margin: 0.3rem 0 0;
+	}
+
+	/* =====================================================================
+	   TITLE PAGE
+	   ===================================================================== */
+	.title-page {
+		min-height: 60vh;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+	}
+
+	.title-page-content {
+		text-align: center;
+	}
+
+	.title-kanji {
+		font-family: var(--font-display), 'Cormorant Garamond', Georgia, serif;
+		font-size: clamp(2rem, 6vw, 3.75rem);
+		letter-spacing: 0.35em;
+		color: var(--ink);
+		margin-bottom: 1.75rem;
+		line-height: 1;
+	}
+
+	.title-english {
+		font-family: var(--font-display), 'Cormorant Garamond', Georgia, serif;
+		font-size: clamp(1.4rem, 3.5vw, 2.25rem);
+		font-weight: 400;
+		font-style: italic;
+		color: var(--ink);
+		margin: 0 0 1rem;
+		letter-spacing: 0.02em;
+	}
+
+	.title-tagline {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.85rem;
+		letter-spacing: 0.1em;
+		color: var(--ink-mid);
+		margin: 0;
+	}
+
+	/* =====================================================================
+	   BOOK TEXT
+	   ===================================================================== */
+	.book-text {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 1rem;
+		line-height: 1.9;
+		color: var(--ink);
+	}
+
+	.book-text p {
+		margin-bottom: 1.3rem;
+	}
+
+	.book-text p:last-child {
+		margin-bottom: 0;
+	}
+
+	.book-text em {
+		font-style: italic;
+	}
+
+	.book-text blockquote {
+		margin: 1.75rem 0;
+		padding: 0.75rem 1.5rem;
+		border-left: 2px solid var(--ink-mid);
+		font-style: italic;
+		color: var(--ink-mid);
+	}
+
+	.mantra-english {
+		text-align: center;
+		margin-top: 1.75rem !important;
+		font-size: 1.05rem;
+	}
+
+	/* =====================================================================
+	   JAPANESE SUTRA
+	   ===================================================================== */
+	.sutra-text {
+		font-family:
+			'Noto Serif JP',
+			'Hiragino Mincho Pro',
+			'Yu Mincho',
+			'游明朝',
+			'MS Mincho',
+			'Source Serif 4',
+			Georgia,
+			serif;
+		font-size: 1.05rem;
+		line-height: 2.3;
+		letter-spacing: 0.06em;
+		color: var(--ink);
+		text-align: justify;
+		word-break: break-all;
+		margin-bottom: 2.5rem;
+	}
+
+	.mantra-jp {
+		font-family:
+			'Noto Serif JP',
+			'Hiragino Mincho Pro',
+			'Yu Mincho',
+			'Source Serif 4',
+			Georgia,
+			serif;
+		font-size: 1.25rem;
+		letter-spacing: 0.18em;
+		text-align: center;
+		color: var(--ink);
+		margin: 0 0 2rem;
+		padding: 1.25rem 0;
+		border-top: 1px solid var(--ink-faint);
+		border-bottom: 1px solid var(--ink-faint);
+	}
+
+	.sutra-end {
+		font-family: var(--font-display), 'Cormorant Garamond', Georgia, serif;
+		font-size: 1.05rem;
+		letter-spacing: 0.35em;
+		text-align: center;
+		color: var(--ink-mid);
+		margin: 0;
+	}
+
+	/* =====================================================================
+	   ILLUSTRATIONS
+	   ===================================================================== */
+	.book-illustration {
+		text-align: center;
+		margin: 3.5rem 0;
+		padding: 2rem 0;
+	}
+
+	.sumi-e {
+		width: min(280px, 92%);
+		height: auto;
+		color: var(--ink);
+		display: block;
+		margin: 0 auto 1rem;
+	}
+
+	.illustration-caption {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.72rem;
+		letter-spacing: 0.2em;
+		color: var(--ink-mid);
+		margin: 0;
+	}
+
+	/* =====================================================================
+	   EXPLANATIONS
+	   ===================================================================== */
+	.explanation {
+		margin-bottom: 3.25rem;
+		padding-bottom: 3.25rem;
+		border-bottom: 1px solid var(--ink-faint);
+	}
+
+	.explanation:last-of-type {
+		border-bottom: none;
+		margin-bottom: 0;
+		padding-bottom: 0;
+	}
+
+	.explanation-header {
+		display: flex;
+		gap: 1.25rem;
+		align-items: flex-start;
+		margin-bottom: 1.5rem;
+	}
+
+	.explanation-number {
+		font-family: var(--font-display), 'Cormorant Garamond', Georgia, serif;
+		font-size: 2.75rem;
+		font-weight: 400;
+		color: var(--ink-mid);
+		line-height: 1;
+		flex-shrink: 0;
+		margin-top: 0.05rem;
+		user-select: none;
+	}
+
+	.explanation-title {
+		font-family: var(--font-sans), 'Inter', system-ui, sans-serif;
+		font-size: 1.05rem;
+		font-weight: 600;
+		color: var(--ink);
+		margin: 0 0 0.3rem;
+		line-height: 1.3;
+	}
+
+	.explanation-kanji {
+		font-family:
+			'Noto Serif JP',
+			'Hiragino Mincho Pro',
+			'Source Serif 4',
+			Georgia,
+			serif;
+		font-size: 0.95rem;
+		letter-spacing: 0.1em;
+		color: var(--ink);
+		margin: 0 0 0.15rem;
+	}
+
+	.explanation-romaji {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.78rem;
+		font-style: italic;
+		letter-spacing: 0.04em;
+		color: var(--ink-mid);
+		margin: 0;
+	}
+
+	/* list styles */
+	.aggregate-list,
+	.mantra-breakdown {
+		margin: 1rem 0 1.25rem 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	.aggregate-list li,
+	.mantra-breakdown li {
+		padding: 0.35rem 0 0.35rem 1.1rem;
+		border-left: 2px solid var(--ink-faint);
+		margin-bottom: 0.5rem;
+		font-size: 0.95rem;
+		line-height: 1.65;
+		color: var(--ink);
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+	}
+
+	.aggregate-list li strong,
+	.mantra-breakdown li strong {
+		font-weight: 600;
+	}
+
+	/* =====================================================================
+	   BACK COVER
+	   ===================================================================== */
+	.back-cover {
+		background-color: var(--washi-deep);
+		color: var(--ink);
+		min-height: 60vh;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-content: center;
+		padding: 5rem 2rem;
+		text-align: center;
+		border-top: 1px solid var(--ink-faint);
+	}
+
+	.back-cover-enso {
+		margin-bottom: 2rem;
+		color: var(--ink);
+	}
+
+	.back-cover-enso svg {
+		width: 72px;
+		height: 72px;
+	}
+
+	.back-cover-content {
+		max-width: 400px;
+	}
+
+	.back-cover-blurb {
+		font-family: var(--font-display), 'Cormorant Garamond', Georgia, serif;
+		font-size: clamp(1.25rem, 3vw, 1.75rem);
+		font-style: italic;
+		font-weight: 400;
+		color: var(--ink);
+		margin: 0 0 1.5rem;
+		line-height: 1.45;
+	}
+
+	.back-cover-description {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.88rem;
+		line-height: 1.85;
+		color: var(--ink-mid);
+		margin: 0 0 1.25rem;
+	}
+
+	.back-cover-tagline {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.82rem;
+		font-style: italic;
+		letter-spacing: 0.04em;
+		color: var(--ink-mid);
+		margin: 0 0 2rem;
+	}
+
+	.back-cover-rule {
+		width: 2.5rem;
+		height: 1px;
+		background-color: var(--ink-mid);
+		margin: 0 auto 1.75rem;
+	}
+
+	.back-cover-kanji {
+		font-family: var(--font-display), 'Cormorant Garamond', Georgia, serif;
+		font-size: 1.15rem;
+		letter-spacing: 0.45em;
+		color: var(--ink-mid);
+		margin: 0;
+	}
+</style>

--- a/src/pages/heart-sutra.astro
+++ b/src/pages/heart-sutra.astro
@@ -91,15 +91,32 @@ import BackButton from '../components/BackButton.astro';
 				<span class="page-number" aria-hidden="true">5</span>
 				<div class="chapter-header">
 					<span class="chapter-label" lang="ja">経文</span>
-					<h2 class="chapter-title" lang="ja">摩訶般若波羅蜜多心経</h2>
+					<h2 class="chapter-title" lang="ja"><ruby>摩訶<rt>まか</rt></ruby><ruby>般若<rt>はんにゃ</rt></ruby><ruby>波羅蜜多<rt>はらみった</rt></ruby><ruby>心経<rt>しんぎょう</rt></ruby></h2>
+				</div>
+
+				<!-- Reading aid toggles -->
+				<div class="reading-controls" role="group" aria-label="Reading aids">
+					<span class="reading-label">Reading aids</span>
+					<button class="reading-btn" id="btn-furigana" aria-pressed="false">
+						<span lang="ja">読み仮名</span><span class="reading-btn-sub">Furigana</span>
+					</button>
+					<button class="reading-btn" id="btn-romaji" aria-pressed="false">
+						<span lang="ja">ローマ字</span><span class="reading-btn-sub">Romaji</span>
+					</button>
 				</div>
 
 				<div class="japanese-sutra">
-					<p class="sutra-text" lang="ja">
-						観自在菩薩行深般若波羅蜜多時照見五蘊皆空度一切苦厄舎利子色不異空空不異色色即是空空即是色受想行識亦復如是舎利子是諸法空相不生不滅不垢不浄不増不減是故空中無色無受想行識無眼耳鼻舌身意無色声香味触法無眼界乃至無意識界無無明亦無無明尽乃至無老死亦無老死尽無苦集滅道無智亦無得以無所得故菩提薩埵依般若波羅蜜多故心無罣礙無罣礙故無有恐怖遠離一切顛倒夢想究竟涅槃三世諸仏依般若波羅蜜多故得阿耨多羅三藐三菩提故知般若波羅蜜多是大神呪是大明呪是無上呪是無等等呪能除一切苦真実不虚故説般若波羅蜜多呪即説呪曰
-					</p>
-					<p class="mantra-jp" lang="ja">羯諦　羯諦　波羅羯諦　波羅僧羯諦　菩提　薩婆訶</p>
+					<p class="sutra-text" lang="ja"><ruby>観自在<rt>かんじざい</rt></ruby><ruby>菩薩<rt>ぼさつ</rt></ruby><ruby>行<rt>ぎょう</rt></ruby><ruby>深<rt>じん</rt></ruby><ruby>般若<rt>はんにゃ</rt></ruby><ruby>波羅蜜多<rt>はらみった</rt></ruby><ruby>時<rt>じ</rt></ruby><ruby>照見<rt>しょうけん</rt></ruby><ruby>五蘊<rt>ごうん</rt></ruby><ruby>皆空<rt>かいくう</rt></ruby><ruby>度<rt>ど</rt></ruby><ruby>一切<rt>いっさい</rt></ruby><ruby>苦厄<rt>くやく</rt></ruby><ruby>舎利子<rt>しゃりし</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>不異<rt>ふい</rt></ruby><ruby>空<rt>くう</rt></ruby><ruby>空<rt>くう</rt></ruby><ruby>不異<rt>ふい</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby>空<rt>くう</rt></ruby><ruby>空<rt>くう</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>受<rt>じゅ</rt></ruby><ruby>想<rt>そう</rt></ruby><ruby>行<rt>ぎょう</rt></ruby><ruby>識<rt>しき</rt></ruby><ruby>亦復如是<rt>やくぶにょぜ</rt></ruby><ruby>舎利子<rt>しゃりし</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>諸法<rt>しょほう</rt></ruby><ruby>空相<rt>くうそう</rt></ruby><ruby>不生<rt>ふしょう</rt></ruby><ruby>不滅<rt>ふめつ</rt></ruby><ruby>不垢<rt>ふく</rt></ruby><ruby>不浄<rt>ふじょう</rt></ruby><ruby>不増<rt>ふぞう</rt></ruby><ruby>不減<rt>ふげん</rt></ruby><ruby>是故<rt>ぜこ</rt></ruby><ruby>空中<rt>くうちゅう</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>受<rt>じゅ</rt></ruby><ruby>想<rt>そう</rt></ruby><ruby>行<rt>ぎょう</rt></ruby><ruby>識<rt>しき</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>眼耳鼻舌身意<rt>げんにびぜっしんい</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>色声香味触法<rt>しきしょうこうみそくほう</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>眼界<rt>げんかい</rt></ruby><ruby>乃至<rt>ないし</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>意識界<rt>いしきかい</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>無明<rt>むみょう</rt></ruby><ruby>亦<rt>やく</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>無明<rt>むみょう</rt></ruby><ruby>尽<rt>じん</rt></ruby><ruby>乃至<rt>ないし</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>老死<rt>ろうし</rt></ruby><ruby>亦<rt>やく</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>老死<rt>ろうし</rt></ruby><ruby>尽<rt>じん</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>苦<rt>く</rt></ruby><ruby>集<rt>しゅう</rt></ruby><ruby>滅<rt>めつ</rt></ruby><ruby>道<rt>どう</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>智<rt>ち</rt></ruby><ruby>亦<rt>やく</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>得<rt>とく</rt></ruby><ruby>以<rt>い</rt></ruby><ruby>無所得<rt>むしょとく</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>菩提薩埵<rt>ぼだいさった</rt></ruby><ruby>依<rt>え</rt></ruby><ruby>般若波羅蜜多<rt>はんにゃはらみった</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>心<rt>しん</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>罣礙<rt>けいげ</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>罣礙<rt>けいげ</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>無有<rt>むう</rt></ruby><ruby>恐怖<rt>くふ</rt></ruby><ruby>遠離<rt>おんり</rt></ruby><ruby>一切<rt>いっさい</rt></ruby><ruby>顛倒<rt>てんどう</rt></ruby><ruby>夢想<rt>むそう</rt></ruby><ruby>究竟<rt>くぎょう</rt></ruby><ruby>涅槃<rt>ねはん</rt></ruby><ruby>三世<rt>さんぜ</rt></ruby><ruby>諸仏<rt>しょぶつ</rt></ruby><ruby>依<rt>え</rt></ruby><ruby>般若波羅蜜多<rt>はんにゃはらみった</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>得<rt>とく</rt></ruby><ruby>阿耨多羅<rt>あのくたら</rt></ruby><ruby>三藐<rt>さんみゃく</rt></ruby><ruby>三菩提<rt>さんぼだい</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>知<rt>ち</rt></ruby><ruby>般若波羅蜜多<rt>はんにゃはらみった</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>大神呪<rt>だいじんしゅ</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>大明呪<rt>だいみょうしゅ</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>無上呪<rt>むじょうしゅ</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>無等等呪<rt>むとうどうしゅ</rt></ruby><ruby>能除<rt>のうじょ</rt></ruby><ruby>一切<rt>いっさい</rt></ruby><ruby>苦<rt>く</rt></ruby><ruby>真実<rt>しんじつ</rt></ruby><ruby>不虚<rt>ふこ</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>説<rt>せつ</rt></ruby><ruby>般若波羅蜜多呪<rt>はんにゃはらみったしゅ</rt></ruby><ruby>即説<rt>そくせつ</rt></ruby><ruby>呪曰<rt>しゅわつ</rt></ruby></p>
+					<p class="mantra-jp" lang="ja"><ruby>羯諦<rt>ぎゃてい</rt></ruby>　<ruby>羯諦<rt>ぎゃてい</rt></ruby>　<ruby>波羅<rt>はら</rt></ruby><ruby>羯諦<rt>ぎゃてい</rt></ruby>　<ruby>波羅僧<rt>はらそう</rt></ruby><ruby>羯諦<rt>ぎゃてい</rt></ruby>　<ruby>菩提<rt>ぼじ</rt></ruby>　<ruby>薩婆訶<rt>そわか</rt></ruby></p>
 					<p class="sutra-end" lang="ja">般若心経</p>
+
+					<!-- Romaji block (shown when romaji toggle is active) -->
+					<div class="romaji-block" aria-label="Romanized pronunciation">
+						<span class="romaji-label">ローマ字 — Romanization</span>
+						<p class="romaji-text">Kan jizai bosatsu gyō jin Hannya Haramitta ji, shōken go'un kai kū, do issai ku yaku. Sha-ri-shi, shiki fu i kū, kū fu i shiki, shiki soku ze kū, kū soku ze shiki. Ju sō gyō shiki, yaku bu nyoze. Sha-ri-shi, ze shohō kū sō, fu shō fu metsu, fu ku fu jō, fu zō fu gen. Ze ko kū chū, mu shiki, mu ju sō gyō shiki, mu gen ni bi zetsu shin i, mu shiki shō kō mi soku hō, mu gen kai nai shi mu i shiki kai. Mu mumyō, yaku mu mumyō jin, nai shi mu rōshi, yaku mu rōshi jin. Mu ku shū metsu dō, mu chi, yaku mu toku. I mu shotoku ko, bodaisatta, e Hannya Haramitta ko, shin mu keige, mu keige ko, mu u kufu, on-ri issai tendō musō, kugyō Nehan. Sanze shobutsu, e Hannya Haramitta ko, toku Anokutara Sanmyaku Sanbodai. Ko chi Hannya Haramitta, ze dai jin shū, ze dai myō shū, ze mu jō shū, ze mu tō dō shū, nō jo issai ku, shinjitsu fuko. Ko setsu Hannya Haramitta shū, soku setsu shū watsu:</p>
+						<p class="romaji-mantra">Gyatei gyatei, hara gyatei, harasō gyatei, boji sowaka.</p>
+						<p class="romaji-text romaji-end">Hannya Shingyō.</p>
+					</div>
 				</div>
 			</div>
 
@@ -205,7 +222,7 @@ import BackButton from '../components/BackButton.astro';
 						<span class="explanation-number" aria-hidden="true" lang="ja">一</span>
 						<div>
 							<h3 class="explanation-title">Form is Emptiness, Emptiness is Form</h3>
-							<p class="explanation-kanji" lang="ja">色即是空、空即是色</p>
+							<p class="explanation-kanji" lang="ja"><ruby>色<rt>しき</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby>空<rt>くう</rt></ruby>、<ruby>空<rt>くう</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby>色<rt>しき</rt></ruby></p>
 							<p class="explanation-romaji">Shiki soku ze kū, kū soku ze shiki</p>
 						</div>
 					</div>
@@ -232,7 +249,7 @@ import BackButton from '../components/BackButton.astro';
 						<span class="explanation-number" aria-hidden="true" lang="ja">二</span>
 						<div>
 							<h3 class="explanation-title">The Five Aggregates are Empty</h3>
-							<p class="explanation-kanji" lang="ja">五蘊皆空</p>
+							<p class="explanation-kanji" lang="ja"><ruby>五蘊<rt>ごうん</rt></ruby><ruby>皆空<rt>かいくう</rt></ruby></p>
 							<p class="explanation-romaji">Goun kai kū</p>
 						</div>
 					</div>
@@ -292,7 +309,7 @@ import BackButton from '../components/BackButton.astro';
 						<span class="explanation-number" aria-hidden="true" lang="ja">三</span>
 						<div>
 							<h3 class="explanation-title">The Great Mantra</h3>
-							<p class="explanation-kanji" lang="ja">羯諦羯諦…</p>
+							<p class="explanation-kanji" lang="ja"><ruby>羯諦<rt>ぎゃてい</rt></ruby><ruby>羯諦<rt>ぎゃてい</rt></ruby>…</p>
 							<p class="explanation-romaji">Gyatei gyatei…</p>
 						</div>
 					</div>
@@ -899,4 +916,179 @@ import BackButton from '../components/BackButton.astro';
 		color: var(--ink-mid);
 		margin: 0;
 	}
+
+	/* =====================================================================
+	   READING CONTROLS
+	   ===================================================================== */
+	.reading-controls {
+		display: flex;
+		align-items: center;
+		gap: 0.6rem;
+		flex-wrap: wrap;
+		margin-bottom: 2rem;
+		padding: 0.65rem 0.9rem;
+		border: 1px solid var(--ink-faint);
+		border-radius: 3px;
+	}
+
+	.reading-label {
+		font-family: var(--font-sans), 'Inter', system-ui, sans-serif;
+		font-size: 0.62rem;
+		letter-spacing: 0.22em;
+		text-transform: uppercase;
+		color: var(--ink-mid);
+		flex-shrink: 0;
+		margin-right: 0.1rem;
+	}
+
+	.reading-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.28rem 0.75rem;
+		border: 1px solid var(--ink-faint);
+		border-radius: 2rem;
+		background: transparent;
+		color: var(--ink-mid);
+		cursor: pointer;
+		font-size: 0.82rem;
+		font-family:
+			'Noto Serif JP',
+			'Hiragino Mincho Pro',
+			'Source Serif 4',
+			Georgia,
+			serif;
+		transition:
+			background-color 0.18s ease,
+			color 0.18s ease,
+			border-color 0.18s ease;
+		line-height: 1.5;
+	}
+
+	.reading-btn:hover {
+		border-color: var(--ink);
+		color: var(--ink);
+	}
+
+	.reading-btn.active {
+		background-color: var(--ink);
+		color: var(--washi);
+		border-color: var(--ink);
+	}
+
+	.reading-btn-sub {
+		font-size: 0.66rem;
+		font-family: var(--font-sans), 'Inter', system-ui, sans-serif;
+		opacity: 0.72;
+		letter-spacing: 0.04em;
+	}
+
+	/* =====================================================================
+	   RUBY / FURIGANA
+	   ===================================================================== */
+	/* Hidden by default — rt takes no space, kanji flows normally */
+	ruby rt {
+		display: none;
+		font-size: 0.5em;
+		line-height: 1;
+		letter-spacing: 0.02em;
+		font-family:
+			'Noto Sans JP',
+			'Hiragino Kaku Gothic Pro',
+			'Yu Gothic',
+			system-ui,
+			sans-serif;
+		color: var(--ink-mid);
+	}
+
+	/* Restore browser-native ruby-text positioning when toggled on */
+	.furigana-active ruby rt {
+		display: revert;
+	}
+
+	/* Extra line-height to accommodate furigana above kanji */
+	.furigana-active .sutra-text {
+		line-height: 3.5;
+	}
+
+	.furigana-active .mantra-jp {
+		line-height: 3.2;
+	}
+
+	.furigana-active .explanation-kanji {
+		line-height: 2.8;
+	}
+
+	/* Chapter title furigana (smaller, as it's in display context) */
+	.furigana-active .chapter-title[lang='ja'] {
+		line-height: 2.2;
+	}
+
+	/* =====================================================================
+	   ROMAJI BLOCK
+	   ===================================================================== */
+	.romaji-block {
+		display: none;
+		margin-top: 2.25rem;
+		padding-top: 1.75rem;
+		border-top: 1px solid var(--ink-faint);
+	}
+
+	.romaji-active .romaji-block {
+		display: block;
+	}
+
+	.romaji-label {
+		display: block;
+		font-family: var(--font-sans), 'Inter', system-ui, sans-serif;
+		font-size: 0.6rem;
+		letter-spacing: 0.38em;
+		text-transform: uppercase;
+		color: var(--ink-mid);
+		margin-bottom: 1rem;
+	}
+
+	.romaji-text {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.875rem;
+		line-height: 2.1;
+		color: var(--ink-mid);
+		font-style: italic;
+		margin-bottom: 0;
+	}
+
+	.romaji-mantra {
+		font-family: var(--font-body), 'Source Serif 4', Georgia, serif;
+		font-size: 0.98rem;
+		text-align: center;
+		font-style: italic;
+		color: var(--ink-mid);
+		margin: 1.5rem 0 0.25rem;
+		letter-spacing: 0.04em;
+	}
+
+	.romaji-end {
+		text-align: center;
+		margin-top: 0.25rem;
+		font-size: 0.82rem;
+		letter-spacing: 0.1em;
+	}
 </style>
+
+<script>
+	const page = document.querySelector<HTMLElement>('.heart-sutra-page');
+	const btnFurigana = document.getElementById('btn-furigana');
+	const btnRomaji   = document.getElementById('btn-romaji');
+
+	btnFurigana?.addEventListener('click', () => {
+		const on = page?.classList.toggle('furigana-active') ?? false;
+		btnFurigana.classList.toggle('active', on);
+		btnFurigana.setAttribute('aria-pressed', String(on));
+	});
+
+	btnRomaji?.addEventListener('click', () => {
+		const on = page?.classList.toggle('romaji-active') ?? false;
+		btnRomaji.classList.toggle('active', on);
+		btnRomaji.setAttribute('aria-pressed', String(on));
+	});
+</script>

--- a/src/pages/heart-sutra.astro
+++ b/src/pages/heart-sutra.astro
@@ -17,10 +17,10 @@ import BackButton from '../components/BackButton.astro';
 
 			<!-- Enso Circle (animated brushstroke) -->
 			<div class="enso-wrapper" aria-hidden="true">
-				<svg class="enso" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+				<svg class="enso" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" overflow="visible">
 					<defs>
 						<!-- Low baseFrequency = coarse bristle marks; high scale = bold ink distortion -->
-						<filter id="enso-ink" x="-18%" y="-18%" width="136%" height="136%" color-interpolation-filters="sRGB">
+						<filter id="enso-ink" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
 							<feTurbulence type="fractalNoise" baseFrequency="0.04 0.13" numOctaves="5" seed="7" result="noise"/>
 							<feDisplacementMap in="SourceGraphic" in2="noise" scale="13" xChannelSelector="R" yChannelSelector="G"/>
 						</filter>
@@ -29,21 +29,21 @@ import BackButton from '../components/BackButton.astro';
 					  Path is a near-circle with slight asymmetry (control points
 					  vary a few px) to mimic a hand-drawn brushstroke.
 					  The gap sits at the top (~11 o'clock) between the
-					  startpoint (84,18) and the endpoint (109,17).
-					  The stroke draws left-to-right: starting at the left edge
-					  of the gap, sweeping counter-clockwise through the bottom,
-					  and arriving at the right edge of the gap.
+					  startpoint (62,22) at ~10-o'clock and endpoint (138,22) at ~2-o'clock.
+					  Gap is 76 px wide (> stroke-width 40) so it stays open.
+					  Stroke draws left-to-right: sweeping counter-clockwise
+					  through the bottom and arriving at the right gap edge.
 					-->
 					<path
 						class="enso-circle"
-						d="M 84 18
-						   C 53 18, 16 51, 15 97
+						d="M 62 22
+						   C 38 38, 16 51, 15 97
 						   C 14 145, 49 183, 97 184
 						   C 145 185, 182 149, 184 102
-						   C 186 55, 156 15, 109 17"
+						   C 186 55, 162 38, 138 22"
 						fill="none"
 						stroke="currentColor"
-						stroke-width="44"
+						stroke-width="40"
 						stroke-linecap="round"
 						filter="url(#enso-ink)"
 					/>

--- a/src/pages/heart-sutra.astro
+++ b/src/pages/heart-sutra.astro
@@ -8,16 +8,58 @@ import BackButton from '../components/BackButton.astro';
 	description="A bunkobon pocket guide to the Heart Sutra (般若心経). Complete text in Japanese and English with explanations of its key teachings on emptiness, non-duality, and liberation."
 >
 	<div class="heart-sutra-page">
-
 		<!-- ============================================================
 		     BOOK COVER
 		     ============================================================ -->
 		<section class="book-cover">
 			<a href="/" class="back-link" aria-label="Back to home">← back</a>
 
-			<!-- Enso Circle (static asset, pulsing) -->
+			<!-- Enso Circle — hand-painted sumi-e path, revealed by CSS conic mask -->
 			<div class="enso-wrapper" aria-hidden="true">
-				<img src="/enso.svg" class="enso" alt="" role="presentation">
+				<svg
+					xmlns="http://www.w3.org/2000/svg"
+					viewBox="0 0 137.71 135.81"
+					class="enso"
+					aria-hidden="true"
+				>
+					<path
+						class="enso-path"
+						d="M83.70583 20.45218c-.003-.009.16318.0204.48546.0861.32227.0657.51636.0848 1.1344.25197.61828.16643 1.121.2436 2.0044.53475.88346.29122 1.6538.49221 2.771.92691 1.1171.4347 2.1071.81687 3.4256 1.4098 1.3185.59291 2.2829 1.0426 3.7304 1.8778 1.4475.83521 2.5994 1.4811 4.1225 2.5748 1.5232 1.0938 2.7727 2.0128 4.3186 3.3711 1.5458 1.3583 2.7945 2.5973 4.3116 4.2165s2.6179 3.0294 3.9668 4.964c1.349 1.9346 2.4501 3.5966 3.562 5.8095s2.1037 4.1494 2.9174 6.5904c.81368 2.4411 1.4776 4.7573 2.0682 7.3389.59066 2.5816.79903 5.0121 1.009 7.7059.21002 2.6938.0594 5.2437-.13667 7.9708-.19604 2.727-.72953 5.3248-1.3371 8.0015-.60755 2.6767-1.5153 5.2522-2.5163 7.7963-1.001 2.5442-2.2876 5.0164-3.6418 7.3542-1.3543 2.3378-3.001 4.6252-4.6513 6.696s-3.6043 4.1113-5.4823 5.8698-4.0673 3.5182-6.0982 4.9345c-2.031 1.4164-4.3783 2.8932-6.4847 3.9527-2.1064 1.0596-4.4484 2.1041-6.516 2.9076-2.0676.80347-4.5709 1.5783-6.5756 2.0396-2.0046.46135-4.2903.92586-6.1492 1.1669-1.8588.24099-4.0268.44599-5.6962.49729-1.6695.0513-3.4462.0317-4.8907.005-1.4444-.0263-3.2219-.23011-4.4112-.37009-1.1894-.14001-2.4878-.338-3.4042-.4908-.91638-.15284-1.9402-.36099-2.565-.49474-.62487-.13374-1.1032-.23372-1.4245-.29746-.3213-.0637-.48558-.0913-.48238-.0802.006.0178.0142.0354.0228.053.009.0173.0195.0346.0315.0515.0115.017.0251.0335.0393.0501.0143.0163.03.0327.0466.0488.0168.0163.0344.0321.0535.0477.019.0158.0388.0313.0596.0466.021.0153.0426.0307.0652.0456.0226.015.0461.0299.0702.0449.0245.0135.049.0294.0746.044.0258.0131.0515.0291.0784.0433.0271.0127.0538.0286.0815.0428.0279.0129.0557.0283.0841.0423.0287.0123.0571.028.0861.0419.0293.0125.0582.0277.0875.0419.0296.0126.0589.0278.0882.0415.0297.0126.059.0278.0884.0416.0297.0126.059.0276.088.0416.0295.0125.0583.0277.087.0416.029.0124.0574.0278.0855.0418.0285.0123.0559.0281.0832.0421.0276.0128.0541.0284.0804.0428.0267.0126.0519.0288.0771.043.0254.0131.0493.029.073.0439.024.0134.0464.0296.0685.0445.022.0149.0431.0302.0633.0455s.0394.0307.0574.0464c.0181.0158.0351.0314.0512.0473.0158.0161.0306.0321.0441.0484.0134.0162.0257.0328.0365.0496.0107.0168.0202.0338.0284.051.008.0175.0147.0346.0195.0524.005.0176.009.0356.01.0541-.003.0167.13827.0682.417.15266.27866.0846 1.0042.25075 1.5539.37111.54969.12057 1.5274.34707 2.3332.474.80577.1269 2.0285.34704 3.073.45315 1.0446.10605 2.4968.25836 3.7608.3195 1.264.0611 2.9229.0901 4.3852.0853 1.4622-.005 3.576-.16328 5.2075-.33272s3.8662-.51057 5.6292-.87195c1.7629-.36132 4.0723-.95319 5.926-1.5259 1.8537-.57264 4.1789-1.4649 6.0812-2.2605 1.9023-.79562 4.4063-2.0635 6.2636-3.1761s4.0621-2.5664 5.8723-3.9016c1.8102-1.3353 4.0175-3.2158 5.6632-4.8439s3.4712-3.6516 4.9807-5.4681 3.1395-4.2469 4.3791-6.2901c1.2397-2.0432 2.6149-4.598 3.5381-6.8126.92321-2.2145 1.8559-4.7511 2.5481-7.0385.69249-2.2874 1.3176-5.0128 1.6524-7.3508.33474-2.3379.57759-4.9104.67449-7.2232.0969-2.3129.007-4.9177-.23313-7.1542-.23958-2.2365-.61149-4.5972-1.0506-6.7171-.43917-2.1199-1.0546-4.3849-1.7593-6.3226-.70466-1.9377-1.4675-3.9236-2.3009-5.6754-.83347-1.7518-1.7521-3.4991-2.6756-5.0435-.9235-1.5443-1.916-3.0503-2.8871-4.3719-.97115-1.3216-1.9533-2.6044-2.9268-3.6952-.97352-1.0908-1.9201-2.108-2.8058-3.0114-.8857-.90346-1.7405-1.7358-2.5431-2.4123-.8026-.67648-1.5024-1.3135-2.149-1.8102-.64656-.49677-1.1953-.92089-1.6386-1.2669-.44331-.34605-.7985-.59773-1.0323-.77053-.23381-.1728-.35087-.26733-.34291-.27898.007-.0118.14064.0625.39074.21631.25006.1539.62655.39279 1.0875.7245.46095.33168 1.0275.7434 1.6921 1.2294.6646.48597 1.4408 1.1034 2.2285 1.8126.78772.70911 1.6941 1.5039 2.5989 2.4057.90485.90179 1.8775 1.9349 2.87 3.0277.99248 1.0928 2.004 2.4173 2.9933 3.7453.98936 1.328 2.0044 2.8856 2.9447 4.4402.94036 1.5546 1.8726 3.3621 2.7211 5.1277.84849 1.7656 1.7342 3.8737 2.3568 5.8603.62269 1.9866 1.285 4.2313 1.7335 6.3708.44845 2.1395.79312 4.5748 1.0391 6.8326.24601 2.2578.2681 4.9618.17353 7.2974-.0946 2.3355-.39866 4.977-.73407 7.3381-.33543 2.3611-1.0757 5.1656-1.7726 7.476-.69703 2.3104-1.7025 5.108-2.7444 7.2953s-2.3636 4.6685-3.614 6.7328c-1.2503 2.0642-3.0413 4.5061-4.5643 6.3416s-3.5566 4.0842-5.2946 5.6478-3.867 3.3386-5.6936 4.6891-4.3253 2.9563-6.251 3.9919c-1.9257 1.0357-4.312 2.1982-6.2318 3.0052-1.9198.80705-4.3533 1.6221-6.2242 2.2051-1.8709.58294-4.2826 1.0824-6.0622 1.4532-1.7796.37077-4.1089.60483-5.7563.78311-1.6474.17827-3.8463.21587-5.3236.22941-1.4772.0136-3.5152-.0587-4.7886-.1742-1.2735-.11546-2.779-.26924-3.8297-.41745s-2.327-.36017-3.137-.51557c-.80995-.15538-1.8448-.36254-2.3981-.49679-.5533-.1342-.97811-.23638-1.2653-.30387-.2872-.0677-.43676-.10088-.43954-.0973-.0101.0143.17206.0796.53713.19307.36512.11337 1.2553.39165 1.9817.56197.72636.17025 1.9675.49504 3.0362.68121 1.0687.1862 2.6484.46762 4.0372.63333 1.3887.1657 3.6285.41278 5.3155.44111 1.687.0283 4.1998.0795 6.1438-.083 1.944-.16253 4.6744-.43567 6.8275-.83207 2.1531-.39643 5.0198-1.0966 7.3293-1.7594 2.3095-.66277 5.5104-1.96 7.8724-3.0253 2.3619-1.0653 5.4879-2.8509 7.8109-4.3306 2.323-1.4798 5.2411-3.8047 7.4323-5.6927 2.1912-1.8881 5.0267-4.9087 6.8809-7.2741s4.0701-5.6054 5.5964-8.2961 3.3675-6.5546 4.3435-9.5564c.97591-3.0017 2.0747-6.8541 2.5919-10.006.51722-3.1521.84166-7.1313.88127-10.338.0397-3.2068-.36892-7.3907-.95421-10.531-.58532-3.1406-1.6274-6.8763-2.6477-9.8641-1.02-2.9879-2.7729-6.6084-4.3104-9.2942s-3.6573-5.7044-5.5085-8.0742-4.4838-5.0826-6.6706-6.9789-4.8858-4.0035-7.2115-5.4838c-2.3256-1.4802-5.1654-3.0773-7.5371-4.1278-2.3716-1.0505-5.0698-2.0455-7.3562-2.7942-2.2864-.74881-5.0675-1.3539-7.2305-1.7153-2.163-.36138-4.5673-.63333-6.5178-.76267-1.9506-.12936-4.107-.12197-5.7978-.0683-1.6909.0536-3.5521.2118-4.9442.39049-1.392.17869-2.7792.40208-3.8532.58917-1.074.18707-2.1227.43572-2.8575.59467-.7349.15864-1.4353.34654-1.8129.43816-.37764.0914-.57492.12959-.57984.11103-.005-.0185.18291-.0919.55145-.21648.36849-.12467 1.0684-.34582 1.7962-.53478.72782-.1888 1.7823-.46841 2.851-.68232 1.0687-.21392 2.4674-.46512 3.8555-.66771 1.3881-.20262 3.2864-.38667 4.9754-.46149 1.689-.0748 3.8912-.10172 5.8416.009 1.9503.11075 4.4076.37056 6.5715.71584 2.1638.3453 5.0315.95423 7.3203 1.6891 2.2888.73489 5.0482 1.7376 7.4224 2.7762 2.3742 1.0387 5.305 2.6675 7.6337 4.1377 2.3286 1.4702 5.1148 3.6243 7.3049 5.512 2.1901 1.8878 4.9266 4.686 6.7814 7.0486s4.043 5.4569 5.5841 8.1362c1.5411 2.6794 3.1414 6.226 4.307 9.1559 1.1655 2.9299 2.1938 7.0622 2.7832 10.198.58937 3.1354 1.0332 7.4655.99827 10.668-.0349 3.2021-.34912 7.2971-.86099 10.445s-1.6162 7.1197-2.586 10.118c-.96985 2.9982-2.8461 7.0215-4.3652 9.71s-3.7778 6.0428-5.6239 8.4072-4.6088 5.1979-6.6973 7.1902-5.4244 4.5398-7.7378 6.0228-5.5287 3.3602-7.8808 4.4312-5.3457 2.2312-7.6107 3.0122c-2.265.78102-5.588 1.5368-7.7318 1.9444-2.1438.40761-4.9582.73246-6.8937.90906-1.9354.17662-4.5421.17349-6.2217.16238-1.6796-.0112-4.0238-.21503-5.407-.3603-1.3832-.14529-3.0177-.39597-4.0822-.55866-1.0645-.16268-2.3659-.45627-3.0897-.59951-.72383-.14333-1.6808-.38964-2.0452-.47317-.36449-.0834-.54729-.11721-.53642-.0977.0216.0383.25995.13799.70175.29483.44171.15703 1.5149.46695 2.3623.69169.84723.22546 2.3214.56797 3.5534.8157 1.2321.24771 3.5224.63175 5.1241.78038 1.6017.14861 4.2491.3763 6.1812.35647 1.9321-.0199 4.8878-.11456 7.1018-.36087 2.214-.24612 5.8374-.78706 8.2498-1.4234 2.4123-.63651 5.7252-1.6722 8.2887-2.6221 2.5633-.95048 6.6527-2.9487 9.168-4.4797 2.5149-1.5317 6.065-3.9896 8.4739-5.9836s5.9456-5.4464 8.0197-7.9892c2.0742-2.5427 4.7451-6.3658 6.4823-9.2971 1.7372-2.9314 3.8426-7.738 4.9884-11.051 1.1458-3.3127 2.4132-8.486 2.8788-12.03.46569-3.5444.74788-8.8821.50011-12.49-.24769-3.6078-1.0186-8.8762-1.9634-12.381-.94517-3.5042-2.7362-8.4784-4.3247-11.725-1.5886-3.2465-4.3034-7.7338-6.4542-10.584-2.1509-2.8506-5.6478-6.6974-8.2539-9.0328s-6.7031-5.4391-9.6317-7.1657c-2.9285-1.7266-7.078-3.7401-10.114-4.9586-3.0363-1.2184-7.7544-2.554-10.82-3.1092-3.0655-.55526-7.3155-1.0516-10.245-1.1358-2.9297-.0842-6.9774.13476-9.6762.45819-2.6988.32344-6.4205 1.0934-8.8113 1.742-2.3908.64853-5.7302 1.7764-7.7563 2.6541-2.0262.87756-4.5873 2.1032-6.2601 3.0262-1.6728.92311-3.8177 2.2567-5.126 3.1513-1.3083.89472-3.0785 2.1793-4.0233 2.9685-.94485.78915-2.0465 1.7064-2.671 2.2815-.62464.5749-1.1032 1.0159-1.4258 1.313-.32251.29723-.7494.73837-.7494.73837l3.1233-2.9052 3.0101-2.4452 3.1472-2.2657 3.6106-2.2701 3.418-1.8358 3.5197-1.6351 3.6104-1.429 4.0797-1.2947 3.7736-.94475 3.8255-.72295 4.274-.5101 3.8978-.20992 3.9069.0214 4.3219.30263 3.8792.54336 3.8426.7731 3.7924.99978 3.7281 1.2215 4.0367 1.6415 3.5354 1.7039 3.4274 1.9107 3.6582 2.3596 3.1393 2.3491 2.994 2.5294 2.8394 2.7004 2.9344 3.1999 2.4569 3.0492 2.2755 3.1866 2.2839 3.6903 1.8398 3.4583 1.6372 3.5601 1.5598 4.0616 1.1587 3.7502.93909 3.8141.71529 3.8659.48874 4.354.19623 3.9373-.0371 3.9459-.3401 4.3979-.56504 3.916-.79671 3.8783-1.0252 3.8269-1.4277 4.1989-1.5215 3.6611-1.7356 3.564-1.9436 3.4542-2.4287 3.7065-2.385 3.1607-2.5662 3.0134-3.0743 3.1758-2.94 2.6447-3.0882 2.4686-3.226 2.2853-3.7701 2.2978-3.4985 1.8438-3.6005 1.6394-4.1427 1.5582-3.7908 1.155-3.8546.93343-4.3852.75915-3.9552.41587-3.9768.18249-3.9849-.0528-4.4738-.37759s11.286 1.5335 15.363 1.067c2.818-.32245 7.4575-1.2377 10.73-2.1076 3.273-.87001 9.1469-3.1469 12.548-5.0011 3.4006-1.8543 8.6082-5.2358 11.919-7.9742 3.3106-2.7384 8.2107-7.992 10.974-11.739 2.7635-3.7469 6.8933-11.159 8.6883-16.342 1.795-5.1821 3.7571-14.12 3.942-20.121.18495-6.0005-.94318-15.882-2.8455-21.797-1.9023-5.9148-6.1954-14.83-9.8765-19.711-3.681-4.8812-10.718-12.013-15.824-15.377-5.1059-3.3636-13.339-7.3323-18.446-8.8012-5.107-1.4688-12.71-2.6176-16.585-2.7262-3.8752-.10859-8.4408.23846-8.7661.27822-.32528.0401-2.3446.23911-4.5709.58352-2.2262.34478-6.605 1.3473-9.7103 2.2857-3.1053.93843-8.3354 3.1888-11.771 4.9814-3.4352 1.7926-8.918 5.6062-11.983 8.2742-3.0649 2.668-7.3701 7.3617-9.9879 10.723-2.6178 3.361-6.0594 9.6481-7.7745 13.548-1.715 3.9-3.798 10.78-4.4665 14.789-.66861 4.0087-1.1746 10.312-1.0692 13.982.10541 3.6697.84317 9.643 1.6054 13.029.76218 3.3859 2.5148 8.9366 3.7928 11.866 1.2779 2.9297 3.5626 7.3019 5.0589 9.7252s4.2565 6.1156 5.8123 7.9771 4.0362 4.3873 5.4106 5.7426c5.6852 3.9881 4.2897 2.3216 9.5145 4.3202 7.5889 2.9813 17.616-.24092 19.336-3.5808 1.7209-3.3399-.50799-12.354-9.6623-21.468-1.3847-1.2713-1.979-1.7497-3.5755-3.5234s-1.9926-2.18-3.5708-4.5328c-1.5782-2.3527-2.0662-3.2155-3.4672-6.1145-1.4009-2.899-1.5719-3.5473-2.4883-6.9733-.91644-3.426-1.0219-4.3462-1.2887-8.15-.26686-3.8039-.35637-4.4696.39429-8.8103.75068-4.3407.76421-5.5188 2.6991-9.8673s2.4773-5.7482 5.481-9.5897 4.163-5.003 7.8955-7.9502c3.7324-2.9472 4.7127-3.6356 9.0586-5.4091s5.7372-2.4071 9.7303-3.0121 5.3981-.8679 8.3044-.74648c2.9063.12144 3.9779.17672 4.2132.20649.23528.0298 1.0724.0273 3.2484.39871 2.176.37142 3.5111.47075 6.7628 1.5461 3.2517 1.0753 5.0458 1.6615 8.783 3.7974s5.639 3.4622 9.0978 6.7716 5.2147 5.2805 7.8006 9.7903c2.586 4.5098 4.0398 7.4296 5.2845 12.675 1.2448 5.2452 1.8175 8.8222 1.48 14.176-.33749 5.3533-1.094 9.2812-2.6784 14.148-1.5844 4.8664-3.3532 8.3224-6.1966 12.355-2.8434 4.0325-5.5919 7.068-9.0826 10.095-3.4908 3.0266-6.8433 5.1387-10.556 7.051.24439-.0343.57637-.11468.99076-.23845.41438-.12377.8491-.2745 1.4126-.50951.56352-.23497 1.1612-.46561 1.854-.81976.69285-.35421 1.4231-.69367 2.2254-1.173.80233-.47934 1.633-.9513 2.5246-1.5601.89209-.60824 1.789-1.2319 2.751-1.9713.96201-.7394 1.8908-1.5278 2.9037-2.3982 1.0128-.87037 1.8962-1.7831 2.8913-2.8321.99518-1.049 1.9152-2.0505 2.8591-3.2736.94387-1.2231 1.8326-2.449 2.7606-3.7919.92801-1.3429 1.6416-2.6725 2.4644-4.1694.82279-1.4969 1.4507-2.9208 2.1408-4.5532.69012-1.6324 1.2056-3.1381 1.7397-4.8831.53405-1.745.91845-3.3138 1.2785-5.1446.36036-1.8308.58736-3.4426.76199-5.3299.17463-1.8872.22207-3.5168.20539-5.4298-.0167-1.913-.15985-3.5291-.36755-5.437-.2077-1.908-.54079-3.4773-.93382-5.3503-.39305-1.873-.90501-3.363-1.4726-5.1729-.5679-1.8098-1.0966-3.0496-1.9059-4.7333-.80939-1.6837-1.4384-3.0043-2.3839-4.5686-.94546-1.5643-1.6724-2.7521-2.7316-4.1776-1.0593-1.4254-1.8441-2.474-2.9922-3.7446s-1.948-2.1849-3.1574-3.2886-2.2329-1.9878-3.4271-2.9769c-1.1942-.98907-2.0323-1.5322-3.2354-2.3456s-1.9212-1.2944-3.1014-1.9339c-1.1802-.63949-2.0634-1.1179-3.1634-1.6473-1.1-.52944-1.9011-.8697-2.9024-1.2945-1.0012-.42487-1.6909-.65248-2.575-.98034-.88406-.32787-1.4356-.47412-2.1844-.7149-.74876-.24101-1.1396-.34246-1.7356-.50831l.00009-.00052"
+						fill="currentColor"></path>
+					<!-- Ink-splash particles: tiny drops at the brush's first touch -->
+					<g aria-hidden="true">
+						<circle
+							class="enso-animated splash-1"
+							cx="88.4"
+							cy="16.5"
+							r="1.3"
+							fill="currentColor"></circle>
+						<circle
+							class="enso-animated splash-2"
+							cx="93.1"
+							cy="22.8"
+							r="0.85"
+							fill="currentColor"></circle>
+						<circle
+							class="enso-animated splash-3"
+							cx="79.6"
+							cy="14.0"
+							r="1.05"
+							fill="currentColor"></circle>
+						<circle
+							class="enso-animated splash-4"
+							cx="95.3"
+							cy="15.2"
+							r="0.65"
+							fill="currentColor"></circle>
+						<circle
+							class="enso-animated splash-5"
+							cx="78.2"
+							cy="24.1"
+							r="1.5"
+							fill="currentColor"></circle>
+					</g>
+				</svg>
 			</div>
 
 			<div class="cover-title">
@@ -32,7 +74,6 @@ import BackButton from '../components/BackButton.astro';
 		     BOOK BODY
 		     ============================================================ -->
 		<div class="book-body">
-
 			<!-- ── Title Page ─────────────────────────────────────────── -->
 			<div class="book-page title-page">
 				<span class="page-number" aria-hidden="true">i</span>
@@ -52,23 +93,23 @@ import BackButton from '../components/BackButton.astro';
 				</div>
 				<div class="book-text">
 					<p>
-						The <em>Prajnaparamita Hridaya Sutra</em>, commonly known as the Heart
-						Sutra, is one of the most famous and beloved texts in Mahayana Buddhism.
-						Though it is only 260 characters long in its Chinese translation, it
-						encapsulates the profound heart of Buddhist wisdom.
+						The <em>Prajnaparamita Hridaya Sutra</em>, commonly known as the
+						Heart Sutra, is one of the most famous and beloved texts in Mahayana
+						Buddhism. Though it is only 260 characters long in its Chinese
+						translation, it encapsulates the profound heart of Buddhist wisdom.
 					</p>
 					<p>
 						The sutra is a teaching given by the Bodhisattva Avalokiteshvara to
 						Shariputra, a senior disciple of the Buddha. Its core message is the
-						teaching of <em>Shunyata</em>, or &ldquo;emptiness.&rdquo; This is not a
-						nihilistic &ldquo;nothingness,&rdquo; but a revelation that all things,
-						concepts, and phenomena lack a fixed, independent, and permanent self.
-						They are interconnected and ever-changing.
+						teaching of <em>Shunyata</em>, or &ldquo;emptiness.&rdquo; This is
+						not a nihilistic &ldquo;nothingness,&rdquo; but a revelation that
+						all things, concepts, and phenomena lack a fixed, independent, and
+						permanent self. They are interconnected and ever-changing.
 					</p>
 					<p>
-						This short book presents the sutra in Japanese and English, followed by
-						brief explanations of its key concepts to help you on your journey of
-						understanding.
+						This short book presents the sutra in Japanese and English, followed
+						by brief explanations of its key concepts to help you on your
+						journey of understanding.
 					</p>
 				</div>
 			</div>
@@ -78,30 +119,154 @@ import BackButton from '../components/BackButton.astro';
 				<span class="page-number" aria-hidden="true">5</span>
 				<div class="chapter-header">
 					<span class="chapter-label" lang="ja">経文</span>
-					<h2 class="chapter-title" lang="ja"><ruby>摩訶<rt>まか</rt></ruby><ruby>般若<rt>はんにゃ</rt></ruby><ruby>波羅蜜多<rt>はらみった</rt></ruby><ruby>心経<rt>しんぎょう</rt></ruby></h2>
+					<h2 class="chapter-title" lang="ja">
+						<ruby>摩訶<rt>まか</rt></ruby><ruby>般若<rt>はんにゃ</rt></ruby
+						><ruby>波羅蜜多<rt>はらみった</rt></ruby><ruby
+							>心経<rt>しんぎょう</rt></ruby
+						>
+					</h2>
 				</div>
 
 				<!-- Reading aid toggles -->
 				<div class="reading-controls" role="group" aria-label="Reading aids">
 					<span class="reading-label">Reading aids</span>
 					<button class="reading-btn" id="btn-furigana" aria-pressed="false">
-						<span lang="ja">読み仮名</span><span class="reading-btn-sub">Furigana</span>
+						<span lang="ja">読み仮名</span><span class="reading-btn-sub"
+							>Furigana</span
+						>
 					</button>
 					<button class="reading-btn" id="btn-romaji" aria-pressed="false">
-						<span lang="ja">ローマ字</span><span class="reading-btn-sub">Romaji</span>
+						<span lang="ja">ローマ字</span><span class="reading-btn-sub"
+							>Romaji</span
+						>
 					</button>
 				</div>
 
 				<div class="japanese-sutra">
-					<p class="sutra-text" lang="ja"><ruby>観自在<rt>かんじざい</rt></ruby><ruby>菩薩<rt>ぼさつ</rt></ruby><ruby>行<rt>ぎょう</rt></ruby><ruby>深<rt>じん</rt></ruby><ruby>般若<rt>はんにゃ</rt></ruby><ruby>波羅蜜多<rt>はらみった</rt></ruby><ruby>時<rt>じ</rt></ruby><ruby>照見<rt>しょうけん</rt></ruby><ruby>五蘊<rt>ごうん</rt></ruby><ruby>皆空<rt>かいくう</rt></ruby><ruby>度<rt>ど</rt></ruby><ruby>一切<rt>いっさい</rt></ruby><ruby>苦厄<rt>くやく</rt></ruby><ruby>舎利子<rt>しゃりし</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>不異<rt>ふい</rt></ruby><ruby>空<rt>くう</rt></ruby><ruby>空<rt>くう</rt></ruby><ruby>不異<rt>ふい</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby>空<rt>くう</rt></ruby><ruby>空<rt>くう</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>受<rt>じゅ</rt></ruby><ruby>想<rt>そう</rt></ruby><ruby>行<rt>ぎょう</rt></ruby><ruby>識<rt>しき</rt></ruby><ruby>亦復如是<rt>やくぶにょぜ</rt></ruby><ruby>舎利子<rt>しゃりし</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>諸法<rt>しょほう</rt></ruby><ruby>空相<rt>くうそう</rt></ruby><ruby>不生<rt>ふしょう</rt></ruby><ruby>不滅<rt>ふめつ</rt></ruby><ruby>不垢<rt>ふく</rt></ruby><ruby>不浄<rt>ふじょう</rt></ruby><ruby>不増<rt>ふぞう</rt></ruby><ruby>不減<rt>ふげん</rt></ruby><ruby>是故<rt>ぜこ</rt></ruby><ruby>空中<rt>くうちゅう</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>受<rt>じゅ</rt></ruby><ruby>想<rt>そう</rt></ruby><ruby>行<rt>ぎょう</rt></ruby><ruby>識<rt>しき</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>眼耳鼻舌身意<rt>げんにびぜっしんい</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>色声香味触法<rt>しきしょうこうみそくほう</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>眼界<rt>げんかい</rt></ruby><ruby>乃至<rt>ないし</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>意識界<rt>いしきかい</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>無明<rt>むみょう</rt></ruby><ruby>亦<rt>やく</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>無明<rt>むみょう</rt></ruby><ruby>尽<rt>じん</rt></ruby><ruby>乃至<rt>ないし</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>老死<rt>ろうし</rt></ruby><ruby>亦<rt>やく</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>老死<rt>ろうし</rt></ruby><ruby>尽<rt>じん</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>苦<rt>く</rt></ruby><ruby>集<rt>しゅう</rt></ruby><ruby>滅<rt>めつ</rt></ruby><ruby>道<rt>どう</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>智<rt>ち</rt></ruby><ruby>亦<rt>やく</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>得<rt>とく</rt></ruby><ruby>以<rt>い</rt></ruby><ruby>無所得<rt>むしょとく</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>菩提薩埵<rt>ぼだいさった</rt></ruby><ruby>依<rt>え</rt></ruby><ruby>般若波羅蜜多<rt>はんにゃはらみった</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>心<rt>しん</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>罣礙<rt>けいげ</rt></ruby><ruby>無<rt>む</rt></ruby><ruby>罣礙<rt>けいげ</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>無有<rt>むう</rt></ruby><ruby>恐怖<rt>くふ</rt></ruby><ruby>遠離<rt>おんり</rt></ruby><ruby>一切<rt>いっさい</rt></ruby><ruby>顛倒<rt>てんどう</rt></ruby><ruby>夢想<rt>むそう</rt></ruby><ruby>究竟<rt>くぎょう</rt></ruby><ruby>涅槃<rt>ねはん</rt></ruby><ruby>三世<rt>さんぜ</rt></ruby><ruby>諸仏<rt>しょぶつ</rt></ruby><ruby>依<rt>え</rt></ruby><ruby>般若波羅蜜多<rt>はんにゃはらみった</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>得<rt>とく</rt></ruby><ruby>阿耨多羅<rt>あのくたら</rt></ruby><ruby>三藐<rt>さんみゃく</rt></ruby><ruby>三菩提<rt>さんぼだい</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>知<rt>ち</rt></ruby><ruby>般若波羅蜜多<rt>はんにゃはらみった</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>大神呪<rt>だいじんしゅ</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>大明呪<rt>だいみょうしゅ</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>無上呪<rt>むじょうしゅ</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby>無等等呪<rt>むとうどうしゅ</rt></ruby><ruby>能除<rt>のうじょ</rt></ruby><ruby>一切<rt>いっさい</rt></ruby><ruby>苦<rt>く</rt></ruby><ruby>真実<rt>しんじつ</rt></ruby><ruby>不虚<rt>ふこ</rt></ruby><ruby>故<rt>こ</rt></ruby><ruby>説<rt>せつ</rt></ruby><ruby>般若波羅蜜多呪<rt>はんにゃはらみったしゅ</rt></ruby><ruby>即説<rt>そくせつ</rt></ruby><ruby>呪曰<rt>しゅわつ</rt></ruby></p>
-					<p class="mantra-jp" lang="ja"><ruby>羯諦<rt>ぎゃてい</rt></ruby>　<ruby>羯諦<rt>ぎゃてい</rt></ruby>　<ruby>波羅<rt>はら</rt></ruby><ruby>羯諦<rt>ぎゃてい</rt></ruby>　<ruby>波羅僧<rt>はらそう</rt></ruby><ruby>羯諦<rt>ぎゃてい</rt></ruby>　<ruby>菩提<rt>ぼじ</rt></ruby>　<ruby>薩婆訶<rt>そわか</rt></ruby></p>
+					<p class="sutra-text" lang="ja">
+						<ruby>観自在<rt>かんじざい</rt></ruby><ruby
+							>菩薩<rt>ぼさつ</rt></ruby
+						><ruby>行<rt>ぎょう</rt></ruby><ruby>深<rt>じん</rt></ruby><ruby
+							>般若<rt>はんにゃ</rt></ruby
+						><ruby>波羅蜜多<rt>はらみった</rt></ruby><ruby>時<rt>じ</rt></ruby
+						><ruby>照見<rt>しょうけん</rt></ruby><ruby>五蘊<rt>ごうん</rt></ruby
+						><ruby>皆空<rt>かいくう</rt></ruby><ruby>度<rt>ど</rt></ruby><ruby
+							>一切<rt>いっさい</rt></ruby
+						><ruby>苦厄<rt>くやく</rt></ruby><ruby>舎利子<rt>しゃりし</rt></ruby
+						><ruby>色<rt>しき</rt></ruby><ruby>不異<rt>ふい</rt></ruby><ruby
+							>空<rt>くう</rt></ruby
+						><ruby>空<rt>くう</rt></ruby><ruby>不異<rt>ふい</rt></ruby><ruby
+							>色<rt>しき</rt></ruby
+						><ruby>色<rt>しき</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby
+							>空<rt>くう</rt></ruby
+						><ruby>空<rt>くう</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby
+							>色<rt>しき</rt></ruby
+						><ruby>受<rt>じゅ</rt></ruby><ruby>想<rt>そう</rt></ruby><ruby
+							>行<rt>ぎょう</rt></ruby
+						><ruby>識<rt>しき</rt></ruby><ruby
+							>亦復如是<rt>やくぶにょぜ</rt></ruby
+						><ruby>舎利子<rt>しゃりし</rt></ruby><ruby>是<rt>ぜ</rt></ruby><ruby
+							>諸法<rt>しょほう</rt></ruby
+						><ruby>空相<rt>くうそう</rt></ruby><ruby>不生<rt>ふしょう</rt></ruby
+						><ruby>不滅<rt>ふめつ</rt></ruby><ruby>不垢<rt>ふく</rt></ruby><ruby
+							>不浄<rt>ふじょう</rt></ruby
+						><ruby>不増<rt>ふぞう</rt></ruby><ruby>不減<rt>ふげん</rt></ruby
+						><ruby>是故<rt>ぜこ</rt></ruby><ruby>空中<rt>くうちゅう</rt></ruby
+						><ruby>無<rt>む</rt></ruby><ruby>色<rt>しき</rt></ruby><ruby
+							>無<rt>む</rt></ruby
+						><ruby>受<rt>じゅ</rt></ruby><ruby>想<rt>そう</rt></ruby><ruby
+							>行<rt>ぎょう</rt></ruby
+						><ruby>識<rt>しき</rt></ruby><ruby>無<rt>む</rt></ruby><ruby
+							>眼耳鼻舌身意<rt>げんにびぜっしんい</rt></ruby
+						><ruby>無<rt>む</rt></ruby><ruby
+							>色声香味触法<rt>しきしょうこうみそくほう</rt></ruby
+						><ruby>無<rt>む</rt></ruby><ruby>眼界<rt>げんかい</rt></ruby><ruby
+							>乃至<rt>ないし</rt></ruby
+						><ruby>無<rt>む</rt></ruby><ruby>意識界<rt>いしきかい</rt></ruby
+						><ruby>無<rt>む</rt></ruby><ruby>無明<rt>むみょう</rt></ruby><ruby
+							>亦<rt>やく</rt></ruby
+						><ruby>無<rt>む</rt></ruby><ruby>無明<rt>むみょう</rt></ruby><ruby
+							>尽<rt>じん</rt></ruby
+						><ruby>乃至<rt>ないし</rt></ruby><ruby>無<rt>む</rt></ruby><ruby
+							>老死<rt>ろうし</rt></ruby
+						><ruby>亦<rt>やく</rt></ruby><ruby>無<rt>む</rt></ruby><ruby
+							>老死<rt>ろうし</rt></ruby
+						><ruby>尽<rt>じん</rt></ruby><ruby>無<rt>む</rt></ruby><ruby
+							>苦<rt>く</rt></ruby
+						><ruby>集<rt>しゅう</rt></ruby><ruby>滅<rt>めつ</rt></ruby><ruby
+							>道<rt>どう</rt></ruby
+						><ruby>無<rt>む</rt></ruby><ruby>智<rt>ち</rt></ruby><ruby
+							>亦<rt>やく</rt></ruby
+						><ruby>無<rt>む</rt></ruby><ruby>得<rt>とく</rt></ruby><ruby
+							>以<rt>い</rt></ruby
+						><ruby>無所得<rt>むしょとく</rt></ruby><ruby>故<rt>こ</rt></ruby
+						><ruby>菩提薩埵<rt>ぼだいさった</rt></ruby><ruby>依<rt>え</rt></ruby
+						><ruby>般若波羅蜜多<rt>はんにゃはらみった</rt></ruby><ruby
+							>故<rt>こ</rt></ruby
+						><ruby>心<rt>しん</rt></ruby><ruby>無<rt>む</rt></ruby><ruby
+							>罣礙<rt>けいげ</rt></ruby
+						><ruby>無<rt>む</rt></ruby><ruby>罣礙<rt>けいげ</rt></ruby><ruby
+							>故<rt>こ</rt></ruby
+						><ruby>無有<rt>むう</rt></ruby><ruby>恐怖<rt>くふ</rt></ruby><ruby
+							>遠離<rt>おんり</rt></ruby
+						><ruby>一切<rt>いっさい</rt></ruby><ruby>顛倒<rt>てんどう</rt></ruby
+						><ruby>夢想<rt>むそう</rt></ruby><ruby>究竟<rt>くぎょう</rt></ruby
+						><ruby>涅槃<rt>ねはん</rt></ruby><ruby>三世<rt>さんぜ</rt></ruby
+						><ruby>諸仏<rt>しょぶつ</rt></ruby><ruby>依<rt>え</rt></ruby><ruby
+							>般若波羅蜜多<rt>はんにゃはらみった</rt></ruby
+						><ruby>故<rt>こ</rt></ruby><ruby>得<rt>とく</rt></ruby><ruby
+							>阿耨多羅<rt>あのくたら</rt></ruby
+						><ruby>三藐<rt>さんみゃく</rt></ruby><ruby
+							>三菩提<rt>さんぼだい</rt></ruby
+						><ruby>故<rt>こ</rt></ruby><ruby>知<rt>ち</rt></ruby><ruby
+							>般若波羅蜜多<rt>はんにゃはらみった</rt></ruby
+						><ruby>是<rt>ぜ</rt></ruby><ruby>大神呪<rt>だいじんしゅ</rt></ruby
+						><ruby>是<rt>ぜ</rt></ruby><ruby>大明呪<rt>だいみょうしゅ</rt></ruby
+						><ruby>是<rt>ぜ</rt></ruby><ruby>無上呪<rt>むじょうしゅ</rt></ruby
+						><ruby>是<rt>ぜ</rt></ruby><ruby
+							>無等等呪<rt>むとうどうしゅ</rt></ruby
+						><ruby>能除<rt>のうじょ</rt></ruby><ruby>一切<rt>いっさい</rt></ruby
+						><ruby>苦<rt>く</rt></ruby><ruby>真実<rt>しんじつ</rt></ruby><ruby
+							>不虚<rt>ふこ</rt></ruby
+						><ruby>故<rt>こ</rt></ruby><ruby>説<rt>せつ</rt></ruby><ruby
+							>般若波羅蜜多呪<rt>はんにゃはらみったしゅ</rt></ruby
+						><ruby>即説<rt>そくせつ</rt></ruby><ruby>呪曰<rt>しゅわつ</rt></ruby
+						>
+					</p>
+					<p class="mantra-jp" lang="ja">
+						<ruby>羯諦<rt>ぎゃてい</rt></ruby>
+						<ruby>羯諦<rt>ぎゃてい</rt></ruby>
+						<ruby>波羅<rt>はら</rt></ruby><ruby>羯諦<rt>ぎゃてい</rt></ruby>
+						<ruby>波羅僧<rt>はらそう</rt></ruby><ruby
+							>羯諦<rt>ぎゃてい</rt></ruby
+						>
+						<ruby>菩提<rt>ぼじ</rt></ruby>
+						<ruby>薩婆訶<rt>そわか</rt></ruby>
+					</p>
 					<p class="sutra-end" lang="ja">般若心経</p>
 
 					<!-- Romaji block (shown when romaji toggle is active) -->
 					<div class="romaji-block" aria-label="Romanized pronunciation">
 						<span class="romaji-label">ローマ字 — Romanization</span>
-						<p class="romaji-text">Kan jizai bosatsu gyō jin Hannya Haramitta ji, shōken go'un kai kū, do issai ku yaku. Sha-ri-shi, shiki fu i kū, kū fu i shiki, shiki soku ze kū, kū soku ze shiki. Ju sō gyō shiki, yaku bu nyoze. Sha-ri-shi, ze shohō kū sō, fu shō fu metsu, fu ku fu jō, fu zō fu gen. Ze ko kū chū, mu shiki, mu ju sō gyō shiki, mu gen ni bi zetsu shin i, mu shiki shō kō mi soku hō, mu gen kai nai shi mu i shiki kai. Mu mumyō, yaku mu mumyō jin, nai shi mu rōshi, yaku mu rōshi jin. Mu ku shū metsu dō, mu chi, yaku mu toku. I mu shotoku ko, bodaisatta, e Hannya Haramitta ko, shin mu keige, mu keige ko, mu u kufu, on-ri issai tendō musō, kugyō Nehan. Sanze shobutsu, e Hannya Haramitta ko, toku Anokutara Sanmyaku Sanbodai. Ko chi Hannya Haramitta, ze dai jin shū, ze dai myō shū, ze mu jō shū, ze mu tō dō shū, nō jo issai ku, shinjitsu fuko. Ko setsu Hannya Haramitta shū, soku setsu shū watsu:</p>
-						<p class="romaji-mantra">Gyatei gyatei, hara gyatei, harasō gyatei, boji sowaka.</p>
+						<p class="romaji-text">
+							Kan jizai bosatsu gyō jin Hannya Haramitta ji, shōken go'un kai
+							kū, do issai ku yaku. Sha-ri-shi, shiki fu i kū, kū fu i shiki,
+							shiki soku ze kū, kū soku ze shiki. Ju sō gyō shiki, yaku bu
+							nyoze. Sha-ri-shi, ze shohō kū sō, fu shō fu metsu, fu ku fu jō,
+							fu zō fu gen. Ze ko kū chū, mu shiki, mu ju sō gyō shiki, mu gen
+							ni bi zetsu shin i, mu shiki shō kō mi soku hō, mu gen kai nai shi
+							mu i shiki kai. Mu mumyō, yaku mu mumyō jin, nai shi mu rōshi,
+							yaku mu rōshi jin. Mu ku shū metsu dō, mu chi, yaku mu toku. I mu
+							shotoku ko, bodaisatta, e Hannya Haramitta ko, shin mu keige, mu
+							keige ko, mu u kufu, on-ri issai tendō musō, kugyō Nehan. Sanze
+							shobutsu, e Hannya Haramitta ko, toku Anokutara Sanmyaku Sanbodai.
+							Ko chi Hannya Haramitta, ze dai jin shū, ze dai myō shū, ze mu jō
+							shū, ze mu tō dō shū, nō jo issai ku, shinjitsu fuko. Ko setsu
+							Hannya Haramitta shū, soku setsu shū watsu:
+						</p>
+						<p class="romaji-mantra">
+							Gyatei gyatei, hara gyatei, harasō gyatei, boji sowaka.
+						</p>
 						<p class="romaji-text romaji-end">Hannya Shingyō.</p>
 					</div>
 				</div>
@@ -118,46 +283,51 @@ import BackButton from '../components/BackButton.astro';
 				<div class="book-text">
 					<p>
 						When the Bodhisattva Avalokiteshvara was practicing the profound
-						Perfection of Wisdom, he perceived that all five aggregates are empty and
-						was saved from all suffering and distress.
+						Perfection of Wisdom, he perceived that all five aggregates are
+						empty and was saved from all suffering and distress.
 					</p>
 					<p>
-						&ldquo;Shariputra, form does not differ from emptiness, emptiness does
-						not differ from form. That which is form is emptiness, that which is
-						emptiness is form. The same is true of feelings, perceptions, impulses,
-						and consciousness.
+						&ldquo;Shariputra, form does not differ from emptiness, emptiness
+						does not differ from form. That which is form is emptiness, that
+						which is emptiness is form. The same is true of feelings,
+						perceptions, impulses, and consciousness.
 					</p>
 					<p>
-						Shariputra, all dharmas are marked with emptiness; they do not appear or
-						disappear, are not tainted or pure, do not increase or decrease.
+						Shariputra, all dharmas are marked with emptiness; they do not
+						appear or disappear, are not tainted or pure, do not increase or
+						decrease.
 					</p>
 					<p>
-						Therefore, in emptiness there is no form, no feeling, no perception, no
-						impulse, no consciousness. No eye, no ear, no nose, no tongue, no body,
-						no mind; no color, no sound, no smell, no taste, no touch, no object of
-						mind; no realm of eyes and so forth until no realm of mind consciousness.
-						No ignorance and also no extinction of it, and so forth until no old age
-						and death and also no extinction of them. No suffering, no origination,
-						no stopping, no path, no cognition, also no attainment with nothing to
-						attain.
+						Therefore, in emptiness there is no form, no feeling, no perception,
+						no impulse, no consciousness. No eye, no ear, no nose, no tongue, no
+						body, no mind; no color, no sound, no smell, no taste, no touch, no
+						object of mind; no realm of eyes and so forth until no realm of mind
+						consciousness. No ignorance and also no extinction of it, and so
+						forth until no old age and death and also no extinction of them. No
+						suffering, no origination, no stopping, no path, no cognition, also
+						no attainment with nothing to attain.
 					</p>
 					<p>
-						The Bodhisattva depends on Prajnaparamita and the mind is no hindrance;
-						without any hindrance no fears exist. Far apart from every perverted view
-						one dwells in Nirvana.
+						The Bodhisattva depends on Prajnaparamita and the mind is no
+						hindrance; without any hindrance no fears exist. Far apart from
+						every perverted view one dwells in Nirvana.
 					</p>
 					<p>
-						All Buddhas in the past, present, and future depend on Prajnaparamita and
-						attain Anuttara Samyak Sambodhi.
+						All Buddhas in the past, present, and future depend on
+						Prajnaparamita and attain Anuttara Samyak Sambodhi.
 					</p>
 					<p>
-						Therefore, know that Prajnaparamita is the great transcendent mantra, is
-						the great bright mantra, is the utmost mantra, is the supreme mantra,
-						which is able to relieve all suffering and is true, not false. So proclaim
-						the Prajnaparamita mantra, proclaim the mantra which says:
+						Therefore, know that Prajnaparamita is the great transcendent
+						mantra, is the great bright mantra, is the utmost mantra, is the
+						supreme mantra, which is able to relieve all suffering and is true,
+						not false. So proclaim the Prajnaparamita mantra, proclaim the
+						mantra which says:
 					</p>
 					<p class="mantra-english">
-						<em>Gate gate p&#257;ragate p&#257;rasamgate bodhi sv&#257;h&#257;.&rdquo;</em>
+						<em
+							>Gate gate p&#257;ragate p&#257;rasamgate bodhi
+							sv&#257;h&#257;.&rdquo;</em
+						>
 					</p>
 				</div>
 			</div>
@@ -171,7 +341,10 @@ import BackButton from '../components/BackButton.astro';
 				</div>
 
 				<!-- Lotus Illustration -->
-				<figure class="book-illustration" aria-label="Sumi-e lotus flower illustration">
+				<figure
+					class="book-illustration"
+					aria-label="Sumi-e lotus flower illustration"
+				>
 					<svg
 						class="sumi-e"
 						viewBox="0 0 240 200"
@@ -179,53 +352,132 @@ import BackButton from '../components/BackButton.astro';
 						aria-hidden="true"
 					>
 						<!-- Roots fading into emptiness below water -->
-						<path d="M 120 132 L 114 155 Q 111 168 109 180" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="3,5" opacity="0.2"/>
-						<path d="M 120 132 L 126 155 Q 129 168 131 180" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="3,5" opacity="0.2"/>
-						<path d="M 118 142 L 106 162 Q 102 174 100 184" fill="none" stroke="currentColor" stroke-width="0.8" stroke-dasharray="2,6" opacity="0.12"/>
+						<path
+							d="M 120 132 L 114 155 Q 111 168 109 180"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.2"
+							stroke-dasharray="3,5"
+							opacity="0.2"></path>
+						<path
+							d="M 120 132 L 126 155 Q 129 168 131 180"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.2"
+							stroke-dasharray="3,5"
+							opacity="0.2"></path>
+						<path
+							d="M 118 142 L 106 162 Q 102 174 100 184"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="0.8"
+							stroke-dasharray="2,6"
+							opacity="0.12"></path>
 						<!-- Water surface -->
-						<path d="M 8 132 Q 60 125, 120 132 Q 180 139, 232 132" fill="none" stroke="currentColor" stroke-width="1.5" opacity="0.5"/>
+						<path
+							d="M 8 132 Q 60 125, 120 132 Q 180 139, 232 132"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+							opacity="0.5"></path>
 						<!-- Stem -->
-						<path d="M 120 132 Q 119 112, 120 96" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+						<path
+							d="M 120 132 Q 119 112, 120 96"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="2.5"
+							stroke-linecap="round"></path>
 						<!-- Leaves -->
-						<path d="M 118 116 Q 88 108, 70 122" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
-						<path d="M 122 116 Q 152 108, 170 122" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.7"/>
+						<path
+							d="M 118 116 Q 88 108, 70 122"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+							stroke-linecap="round"
+							opacity="0.7"></path>
+						<path
+							d="M 122 116 Q 152 108, 170 122"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+							stroke-linecap="round"
+							opacity="0.7"></path>
 						<!-- Center petal -->
-						<path d="M 120 30 Q 113 54, 114 74 Q 116 88, 120 96 Q 124 88, 126 74 Q 127 54, 120 30" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round"/>
+						<path
+							d="M 120 30 Q 113 54, 114 74 Q 116 88, 120 96 Q 124 88, 126 74 Q 127 54, 120 30"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.5"
+							stroke-linecap="round"></path>
 						<!-- Left inner petal -->
-						<path d="M 104 40 Q 98 60, 100 78 Q 104 91, 112 96 Q 112 80, 108 62 Q 104 46, 104 40" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+						<path
+							d="M 104 40 Q 98 60, 100 78 Q 104 91, 112 96 Q 112 80, 108 62 Q 104 46, 104 40"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.4"
+							stroke-linecap="round"></path>
 						<!-- Right inner petal -->
-						<path d="M 136 40 Q 142 60, 140 78 Q 136 91, 128 96 Q 128 80, 132 62 Q 136 46, 136 40" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round"/>
+						<path
+							d="M 136 40 Q 142 60, 140 78 Q 136 91, 128 96 Q 128 80, 132 62 Q 136 46, 136 40"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.4"
+							stroke-linecap="round"></path>
 						<!-- Left outer petal -->
-						<path d="M 82 58 Q 84 78, 90 92 Q 98 102, 110 103 Q 102 86, 94 72 Q 87 60, 82 58" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+						<path
+							d="M 82 58 Q 84 78, 90 92 Q 98 102, 110 103 Q 102 86, 94 72 Q 87 60, 82 58"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.3"
+							stroke-linecap="round"></path>
 						<!-- Right outer petal -->
-						<path d="M 158 58 Q 156 78, 150 92 Q 142 102, 130 103 Q 138 86, 146 72 Q 153 60, 158 58" fill="none" stroke="currentColor" stroke-width="1.3" stroke-linecap="round"/>
+						<path
+							d="M 158 58 Q 156 78, 150 92 Q 142 102, 130 103 Q 138 86, 146 72 Q 153 60, 158 58"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1.3"
+							stroke-linecap="round"></path>
 					</svg>
-					<figcaption class="illustration-caption" lang="ja">形は空に溶ける</figcaption>
+					<figcaption class="illustration-caption" lang="ja">
+						形は空に溶ける
+					</figcaption>
 				</figure>
 
 				<!-- Explanation 1 -->
 				<article class="explanation">
 					<div class="explanation-header">
-						<span class="explanation-number" aria-hidden="true" lang="ja">一</span>
+						<span class="explanation-number" aria-hidden="true" lang="ja"
+							>一</span
+						>
 						<div>
-							<h3 class="explanation-title">Form is Emptiness, Emptiness is Form</h3>
-							<p class="explanation-kanji" lang="ja"><ruby>色<rt>しき</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby>空<rt>くう</rt></ruby>、<ruby>空<rt>くう</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby><ruby>色<rt>しき</rt></ruby></p>
-							<p class="explanation-romaji">Shiki soku ze kū, kū soku ze shiki</p>
+							<h3 class="explanation-title">
+								Form is Emptiness, Emptiness is Form
+							</h3>
+							<p class="explanation-kanji" lang="ja">
+								<ruby>色<rt>しき</rt></ruby><ruby>即是<rt>そくぜ</rt></ruby
+								><ruby>空<rt>くう</rt></ruby>、<ruby>空<rt>くう</rt></ruby><ruby
+									>即是<rt>そくぜ</rt></ruby
+								><ruby>色<rt>しき</rt></ruby>
+							</p>
+							<p class="explanation-romaji">
+								Shiki soku ze kū, kū soku ze shiki
+							</p>
 						</div>
 					</div>
 					<div class="book-text">
 						<p>
 							This is the sutra&rsquo;s most famous and paradoxical statement.
-							&ldquo;Form&rdquo; refers to the physical world, our bodies, and material
-							objects. The sutra asserts that these forms have no permanent, inherent
-							existence. They are &ldquo;empty&rdquo; because they are constantly
-							changing and dependent on other conditions to exist.
+							&ldquo;Form&rdquo; refers to the physical world, our bodies, and
+							material objects. The sutra asserts that these forms have no
+							permanent, inherent existence. They are &ldquo;empty&rdquo;
+							because they are constantly changing and dependent on other
+							conditions to exist.
 						</p>
 						<p>
-							A wave is distinct, yet it is just water. The wave is &ldquo;empty&rdquo;
-							of a separate self; it is the water. Conversely, this
-							&ldquo;emptiness&rdquo; is not apart from the physical world; it
-							manifests as form.
+							A wave is distinct, yet it is just water. The wave is
+							&ldquo;empty&rdquo; of a separate self; it is the water.
+							Conversely, this &ldquo;emptiness&rdquo; is not apart from the
+							physical world; it manifests as form.
 						</p>
 					</div>
 				</article>
@@ -233,10 +485,16 @@ import BackButton from '../components/BackButton.astro';
 				<!-- Explanation 2 -->
 				<article class="explanation">
 					<div class="explanation-header">
-						<span class="explanation-number" aria-hidden="true" lang="ja">二</span>
+						<span class="explanation-number" aria-hidden="true" lang="ja"
+							>二</span
+						>
 						<div>
 							<h3 class="explanation-title">The Five Aggregates are Empty</h3>
-							<p class="explanation-kanji" lang="ja"><ruby>五蘊<rt>ごうん</rt></ruby><ruby>皆空<rt>かいくう</rt></ruby></p>
+							<p class="explanation-kanji" lang="ja">
+								<ruby>五蘊<rt>ごうん</rt></ruby><ruby
+									>皆空<rt>かいくう</rt></ruby
+								>
+							</p>
 							<p class="explanation-romaji">Goun kai kū</p>
 						</div>
 					</div>
@@ -247,21 +505,33 @@ import BackButton from '../components/BackButton.astro';
 						</p>
 						<ol class="aggregate-list">
 							<li><strong>Form</strong> &mdash; The physical body.</li>
-							<li><strong>Feeling</strong> &mdash; Sensations of pleasant, unpleasant, or neutral.</li>
-							<li><strong>Perception</strong> &mdash; Recognizing and labeling things.</li>
-							<li><strong>Mental Formations</strong> &mdash; Thoughts, volitions, and emotions.</li>
+							<li>
+								<strong>Feeling</strong> &mdash; Sensations of pleasant, unpleasant,
+								or neutral.
+							</li>
+							<li>
+								<strong>Perception</strong> &mdash; Recognizing and labeling things.
+							</li>
+							<li>
+								<strong>Mental Formations</strong> &mdash; Thoughts, volitions, and
+								emotions.
+							</li>
 							<li><strong>Consciousness</strong> &mdash; Awareness itself.</li>
 						</ol>
 						<p>
-							Avalokiteshvara sees that none of these parts constitute a permanent
-							&ldquo;I&rdquo;. When we realize our &ldquo;self&rdquo; is empty, we are
-							freed from the suffering that comes from clinging to it.
+							Avalokiteshvara sees that none of these parts constitute a
+							permanent &ldquo;I&rdquo;. When we realize our &ldquo;self&rdquo;
+							is empty, we are freed from the suffering that comes from clinging
+							to it.
 						</p>
 					</div>
 				</article>
 
 				<!-- Torii Gate Illustration -->
-				<figure class="book-illustration" aria-label="Sumi-e torii gate illustration">
+				<figure
+					class="book-illustration"
+					aria-label="Sumi-e torii gate illustration"
+				>
 					<svg
 						class="sumi-e"
 						viewBox="0 0 240 200"
@@ -269,64 +539,141 @@ import BackButton from '../components/BackButton.astro';
 						aria-hidden="true"
 					>
 						<!-- Mist / cliff base -->
-						<path d="M 0 182 Q 120 174, 240 182 L 240 200 L 0 200 Z" fill="currentColor" opacity="0.06"/>
-						<path d="M 0 190 Q 120 183, 240 190 L 240 200 L 0 200 Z" fill="currentColor" opacity="0.05"/>
+						<path
+							d="M 0 182 Q 120 174, 240 182 L 240 200 L 0 200 Z"
+							fill="currentColor"
+							opacity="0.06"></path>
+						<path
+							d="M 0 190 Q 120 183, 240 190 L 240 200 L 0 200 Z"
+							fill="currentColor"
+							opacity="0.05"></path>
 						<!-- Left pillar -->
-						<line x1="74" y1="66" x2="74" y2="182" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+						<line
+							x1="74"
+							y1="66"
+							x2="74"
+							y2="182"
+							stroke="currentColor"
+							stroke-width="7"
+							stroke-linecap="round"></line>
 						<!-- Right pillar -->
-						<line x1="166" y1="66" x2="166" y2="182" stroke="currentColor" stroke-width="7" stroke-linecap="round"/>
+						<line
+							x1="166"
+							y1="66"
+							x2="166"
+							y2="182"
+							stroke="currentColor"
+							stroke-width="7"
+							stroke-linecap="round"></line>
 						<!-- Nuki (second horizontal beam) -->
-						<line x1="58" y1="90" x2="182" y2="90" stroke="currentColor" stroke-width="4.5" stroke-linecap="round"/>
+						<line
+							x1="58"
+							y1="90"
+							x2="182"
+							y2="90"
+							stroke="currentColor"
+							stroke-width="4.5"
+							stroke-linecap="round"></line>
 						<!-- Shimagi (beam directly under kasagi) -->
-						<line x1="44" y1="69" x2="196" y2="69" stroke="currentColor" stroke-width="4" stroke-linecap="round"/>
+						<line
+							x1="44"
+							y1="69"
+							x2="196"
+							y2="69"
+							stroke="currentColor"
+							stroke-width="4"
+							stroke-linecap="round"></line>
 						<!-- Kasagi (top curved beam) -->
-						<path d="M 18 57 Q 120 30, 222 57" fill="none" stroke="currentColor" stroke-width="10" stroke-linecap="round"/>
+						<path
+							d="M 18 57 Q 120 30, 222 57"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="10"
+							stroke-linecap="round"></path>
 						<!-- Mist wisps around pillars -->
-						<path d="M 0 158 Q 38 152, 65 158" fill="none" stroke="currentColor" stroke-width="1" opacity="0.18"/>
-						<path d="M 178 160 Q 205 154, 240 160" fill="none" stroke="currentColor" stroke-width="1" opacity="0.18"/>
-						<path d="M 0 170 Q 50 164, 70 170" fill="none" stroke="currentColor" stroke-width="1" opacity="0.12"/>
-						<path d="M 175 172 Q 205 166, 240 172" fill="none" stroke="currentColor" stroke-width="1" opacity="0.12"/>
+						<path
+							d="M 0 158 Q 38 152, 65 158"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1"
+							opacity="0.18"></path>
+						<path
+							d="M 178 160 Q 205 154, 240 160"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1"
+							opacity="0.18"></path>
+						<path
+							d="M 0 170 Q 50 164, 70 170"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1"
+							opacity="0.12"></path>
+						<path
+							d="M 175 172 Q 205 166, 240 172"
+							fill="none"
+							stroke="currentColor"
+							stroke-width="1"
+							opacity="0.12"></path>
 					</svg>
-					<figcaption class="illustration-caption" lang="ja">彼岸への門</figcaption>
+					<figcaption class="illustration-caption" lang="ja">
+						彼岸への門
+					</figcaption>
 				</figure>
 
 				<!-- Explanation 3 -->
 				<article class="explanation">
 					<div class="explanation-header">
-						<span class="explanation-number" aria-hidden="true" lang="ja">三</span>
+						<span class="explanation-number" aria-hidden="true" lang="ja"
+							>三</span
+						>
 						<div>
 							<h3 class="explanation-title">The Great Mantra</h3>
-							<p class="explanation-kanji" lang="ja"><ruby>羯諦<rt>ぎゃてい</rt></ruby><ruby>羯諦<rt>ぎゃてい</rt></ruby>…</p>
+							<p class="explanation-kanji" lang="ja">
+								<ruby>羯諦<rt>ぎゃてい</rt></ruby><ruby
+									>羯諦<rt>ぎゃてい</rt></ruby
+								>…
+							</p>
 							<p class="explanation-romaji">Gyatei gyatei…</p>
 						</div>
 					</div>
 					<div class="book-text">
 						<p>
-							The sutra concludes with a powerful mantra, a chant that encapsulates
-							the energy of the teaching. It is often left untranslated to preserve
-							its power, but its meaning is approximately:
+							The sutra concludes with a powerful mantra, a chant that
+							encapsulates the energy of the teaching. It is often left
+							untranslated to preserve its power, but its meaning is
+							approximately:
 						</p>
 						<blockquote>
-							&ldquo;Gone, gone, gone beyond, gone altogether beyond, O awakening,
-							hail!&rdquo;
+							&ldquo;Gone, gone, gone beyond, gone altogether beyond, O
+							awakening, hail!&rdquo;
 						</blockquote>
 						<ul class="mantra-breakdown">
-							<li><strong>Gate</strong> &mdash; Gone from the shore of suffering and ignorance.</li>
-							<li><strong>Paragate</strong> &mdash; Gone to the other shore of enlightenment.</li>
-							<li><strong>Parasamgate</strong> &mdash; Gone completely, together with all beings.</li>
+							<li>
+								<strong>Gate</strong> &mdash; Gone from the shore of suffering and
+								ignorance.
+							</li>
+							<li>
+								<strong>Paragate</strong> &mdash; Gone to the other shore of enlightenment.
+							</li>
+							<li>
+								<strong>Parasamgate</strong> &mdash; Gone completely, together with
+								all beings.
+							</li>
 							<li><strong>Bodhi</strong> &mdash; Awakening.</li>
-							<li><strong>Sv&#257;h&#257;</strong> &mdash; An expression of delight, like &ldquo;So be it!&rdquo; or &ldquo;Hallelujah!&rdquo;</li>
+							<li>
+								<strong>Sv&#257;h&#257;</strong> &mdash; An expression of delight,
+								like &ldquo;So be it!&rdquo; or &ldquo;Hallelujah!&rdquo;
+							</li>
 						</ul>
 						<p>
-							Reciting the mantra is a practice to help us let go of our conceptual
-							thinking and cross over from the world of suffering to the shore of
-							liberation.
+							Reciting the mantra is a practice to help us let go of our
+							conceptual thinking and cross over from the world of suffering to
+							the shore of liberation.
 						</p>
 					</div>
 				</article>
-
 			</div><!-- /explanations-page -->
-
 		</div><!-- /book-body -->
 
 		<!-- ============================================================
@@ -341,8 +688,7 @@ import BackButton from '../components/BackButton.astro';
 						stroke="currentColor"
 						stroke-width="5"
 						stroke-linecap="round"
-						opacity="0.35"
-					/>
+						opacity="0.35"></path>
 				</svg>
 			</div>
 			<div class="back-cover-content">
@@ -350,9 +696,9 @@ import BackButton from '../components/BackButton.astro';
 					A timeless guide to the essence of Buddhist wisdom.
 				</p>
 				<p class="back-cover-description">
-					This pocket-sized edition contains the complete text of the Heart Sutra in
-					Japanese and English, along with concise explanations of its most profound
-					teachings on emptiness, non-duality, and liberation.
+					This pocket-sized edition contains the complete text of the Heart
+					Sutra in Japanese and English, along with concise explanations of its
+					most profound teachings on emptiness, non-duality, and liberation.
 				</p>
 				<p class="back-cover-tagline">
 					A perfect companion for meditation and daily reflection.
@@ -361,7 +707,6 @@ import BackButton from '../components/BackButton.astro';
 				<p class="back-cover-kanji" lang="ja">般若心経</p>
 			</div>
 		</section>
-
 	</div><!-- /heart-sutra-page -->
 </Layout>
 
@@ -370,42 +715,42 @@ import BackButton from '../components/BackButton.astro';
 	   CSS VARIABLES — washi-paper palette
 	   ===================================================================== */
 	:root {
-		--washi:        #f4efe5;
-		--washi-deep:   #ece6d9;
-		--ink:          #1c1917;
-		--ink-mid:      rgba(28, 25, 23, 0.55);
-		--ink-faint:    rgba(28, 25, 23, 0.18);
-		--enso-size:    min(300px, 75vw);
+		--washi: #f4efe5;
+		--washi-deep: #ece6d9;
+		--ink: #1c1917;
+		--ink-mid: rgba(28, 25, 23, 0.55);
+		--ink-faint: rgba(28, 25, 23, 0.18);
+		--enso-size: min(300px, 75vw);
 	}
 
 	:global(.dark) {
-		--washi:        #1a1815;
-		--washi-deep:   #141210;
-		--ink:          #e8e2d6;
-		--ink-mid:      rgba(232, 226, 214, 0.55);
-		--ink-faint:    rgba(232, 226, 214, 0.15);
+		--washi: #1a1815;
+		--washi-deep: #141210;
+		--ink: #e8e2d6;
+		--ink-mid: rgba(232, 226, 214, 0.55);
+		--ink-faint: rgba(232, 226, 214, 0.15);
 	}
 
 	/* =====================================================================
 	   FULL-BLEED WRAPPER — cancels Layout padding
 	   ===================================================================== */
 	.heart-sutra-page {
-		margin-top:    -2rem;
+		margin-top: -2rem;
 		margin-bottom: -2rem;
-		margin-left:   -1.5rem;
-		margin-right:  -1.5rem;
+		margin-left: -1.5rem;
+		margin-right: -1.5rem;
 	}
 
 	@media (min-width: 768px) {
 		.heart-sutra-page {
-			margin-left:  -3rem;
+			margin-left: -3rem;
 			margin-right: -3rem;
 		}
 	}
 
 	@media (min-width: 1024px) {
 		.heart-sutra-page {
-			margin-left:  -4rem;
+			margin-left: -4rem;
 			margin-right: -4rem;
 		}
 	}
@@ -477,23 +822,137 @@ import BackButton from '../components/BackButton.astro';
 		width: var(--enso-size);
 		height: var(--enso-size);
 		display: block;
-		animation: enso-pulse 5s ease-in-out infinite;
+		color: var(--ink);
+		transform-origin: center;
+		/* Allow filter output to bleed past the SVG box without clipping */
+		overflow: visible;
+		/*
+			Breath begins after the sweep draw completes (3.5s) + small pause = 3.7s.
+			9s cycle with a held stillness at the exhale — one meditative breath.
+			Hover pauses the breath: the enso holds its presence when you look at it.
+		*/
+		animation: enso-pulse 9s 3.7s ease-in-out infinite;
 	}
 
-	/* Dark mode: invert the hardcoded #1c1917 stroke to near-white */
-	:global(.dark) .enso {
-		filter: invert(1);
+	.enso:hover {
+		animation-play-state: paused;
 	}
 
+	/*
+		Conic-sweep draw: @property lets CSS animate the custom angle, which drives
+		a conic-gradient mask that sweeps clockwise from upper-left — no SVG mask,
+		no black background, just ink appearing from nothingness.
+	*/
+	@property --enso-reveal {
+		syntax: '<angle>';
+		inherits: false;
+		initial-value: 0deg;
+	}
+
+	.enso-path {
+		--enso-reveal: 0deg;
+		-webkit-mask-image: conic-gradient(
+			from -163deg at 50% 50%,
+			black var(--enso-reveal),
+			transparent var(--enso-reveal)
+		);
+		mask-image: conic-gradient(
+			from -163deg at 50% 50%,
+			black var(--enso-reveal),
+			transparent var(--enso-reveal)
+		);
+		animation: enso-draw 3.5s ease-out forwards;
+	}
+
+	@keyframes enso-draw {
+		from {
+			--enso-reveal: 0deg;
+		}
+		to {
+			--enso-reveal: 360deg;
+		}
+	}
+
+	/*
+		Asymmetric breath: 35% exhale → 17% held stillness → 48% return.
+		The pause at the exhale is where meditation lives.
+	*/
 	@keyframes enso-pulse {
-		0%, 100% { opacity: 0.7;  transform: scale(0.97); }
-		50%       { opacity: 1;   transform: scale(1);    }
+		0% {
+			opacity: 1;
+			transform: scale(1);
+		}
+		35% {
+			opacity: 0.72;
+			transform: scale(0.968);
+		}
+		52% {
+			opacity: 0.72;
+			transform: scale(0.968);
+		}
+		100% {
+			opacity: 1;
+			transform: scale(1);
+		}
 	}
 
 	@media (prefers-reduced-motion: reduce) {
 		.enso {
 			animation: none;
 			opacity: 1;
+		}
+		.enso-path {
+			animation: none;
+			--enso-reveal: 360deg;
+		}
+		.splash-1,
+		.splash-2,
+		.splash-3,
+		.splash-4,
+		.splash-5 {
+			display: none;
+		}
+	}
+
+	/* Ink-splash particles: tiny dots scattered at the brush-touch origin */
+	.splash-1,
+	.splash-2,
+	.splash-3,
+	.splash-4,
+	.splash-5 {
+		opacity: 0;
+		transform-box: fill-box;
+		transform-origin: center;
+		animation: ink-splash 1s ease-out forwards;
+	}
+	.splash-1 {
+		animation-delay: 0.04s;
+	}
+	.splash-2 {
+		animation-delay: 0.13s;
+	}
+	.splash-3 {
+		animation-delay: 0.08s;
+	}
+	.splash-4 {
+		animation-delay: 0.19s;
+	}
+	.splash-5 {
+		animation-delay: 0.16s;
+	}
+
+	@keyframes ink-splash {
+		0% {
+			opacity: 0;
+			transform: scale(0.2);
+		}
+		12% {
+			opacity: 0.6;
+			transform: scale(1);
+		}
+		100% {
+			opacity: 0;
+			transform: scale(1.5);
 		}
 	}
 
@@ -682,14 +1141,8 @@ import BackButton from '../components/BackButton.astro';
 	   ===================================================================== */
 	.sutra-text {
 		font-family:
-			'Noto Serif JP',
-			'Hiragino Mincho Pro',
-			'Yu Mincho',
-			'游明朝',
-			'MS Mincho',
-			'Source Serif 4',
-			Georgia,
-			serif;
+			'Noto Serif JP', 'Hiragino Mincho Pro', 'Yu Mincho', '游明朝',
+			'MS Mincho', 'Source Serif 4', Georgia, serif;
 		font-size: 1.05rem;
 		line-height: 2.3;
 		letter-spacing: 0.06em;
@@ -701,12 +1154,8 @@ import BackButton from '../components/BackButton.astro';
 
 	.mantra-jp {
 		font-family:
-			'Noto Serif JP',
-			'Hiragino Mincho Pro',
-			'Yu Mincho',
-			'Source Serif 4',
-			Georgia,
-			serif;
+			'Noto Serif JP', 'Hiragino Mincho Pro', 'Yu Mincho', 'Source Serif 4',
+			Georgia, serif;
 		font-size: 1.25rem;
 		letter-spacing: 0.18em;
 		text-align: center;
@@ -795,11 +1244,7 @@ import BackButton from '../components/BackButton.astro';
 
 	.explanation-kanji {
 		font-family:
-			'Noto Serif JP',
-			'Hiragino Mincho Pro',
-			'Source Serif 4',
-			Georgia,
-			serif;
+			'Noto Serif JP', 'Hiragino Mincho Pro', 'Source Serif 4', Georgia, serif;
 		font-size: 0.95rem;
 		letter-spacing: 0.1em;
 		color: var(--ink);
@@ -863,6 +1308,30 @@ import BackButton from '../components/BackButton.astro';
 	.back-cover-enso svg {
 		width: 72px;
 		height: 72px;
+	}
+
+	/* The back-cover enso breathes gently — an echo of the opening */
+	.back-cover-enso path {
+		animation: back-enso-breathe 9s 1s ease-in-out infinite;
+	}
+
+	@keyframes back-enso-breathe {
+		0%,
+		100% {
+			opacity: 0.35;
+		}
+		40% {
+			opacity: 0.18;
+		}
+		57% {
+			opacity: 0.18;
+		}
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.back-cover-enso path {
+			animation: none;
+		}
 	}
 
 	.back-cover-content {
@@ -947,11 +1416,7 @@ import BackButton from '../components/BackButton.astro';
 		cursor: pointer;
 		font-size: 0.82rem;
 		font-family:
-			'Noto Serif JP',
-			'Hiragino Mincho Pro',
-			'Source Serif 4',
-			Georgia,
-			serif;
+			'Noto Serif JP', 'Hiragino Mincho Pro', 'Source Serif 4', Georgia, serif;
 		transition:
 			background-color 0.18s ease,
 			color 0.18s ease,
@@ -987,10 +1452,7 @@ import BackButton from '../components/BackButton.astro';
 		line-height: 1;
 		letter-spacing: 0.02em;
 		font-family:
-			'Noto Sans JP',
-			'Hiragino Kaku Gothic Pro',
-			'Yu Gothic',
-			system-ui,
+			'Noto Sans JP', 'Hiragino Kaku Gothic Pro', 'Yu Gothic', system-ui,
 			sans-serif;
 		color: var(--ink-mid);
 	}
@@ -1070,9 +1532,10 @@ import BackButton from '../components/BackButton.astro';
 </style>
 
 <script>
+	// ── Reading controls ────────────────────────────────────────────────
 	const page = document.querySelector<HTMLElement>('.heart-sutra-page');
 	const btnFurigana = document.getElementById('btn-furigana');
-	const btnRomaji   = document.getElementById('btn-romaji');
+	const btnRomaji = document.getElementById('btn-romaji');
 
 	btnFurigana?.addEventListener('click', () => {
 		const on = page?.classList.toggle('furigana-active') ?? false;
@@ -1085,4 +1548,56 @@ import BackButton from '../components/BackButton.astro';
 		btnRomaji.classList.toggle('active', on);
 		btnRomaji.setAttribute('aria-pressed', String(on));
 	});
+
+	// ── Enso replay on revisit ──────────────────────────────────────────
+	// Restarts the conic draw + pulse each time the enso re-enters the viewport.
+	// Skipped entirely for prefers-reduced-motion.
+	const ensoWrapper = document.querySelector<HTMLElement>('.enso-wrapper');
+	const ensoSvg = document.querySelector<SVGSVGElement>('.enso');
+	const ensoPath = document.querySelector<SVGPathElement>('.enso-path');
+
+	if (
+		ensoWrapper &&
+		ensoSvg &&
+		ensoPath &&
+		!window.matchMedia('(prefers-reduced-motion: reduce)').matches
+	) {
+		let hasLeft = false;
+
+		const splashes = Array.from(
+			ensoWrapper.querySelectorAll<SVGElement>('[class*="splash-"]'),
+		);
+
+		function restartEnso() {
+			// Strip inline animation overrides, force a single reflow, then
+			// restore — resets all animations to t=0 without a flash.
+			ensoSvg.style.animation = 'none';
+			ensoPath.style.animation = 'none';
+			for (const el of splashes) {
+				el.style.animation = 'none';
+			}
+			void ensoSvg.getBoundingClientRect(); // single reflow
+			ensoSvg.style.animation = '';
+			ensoPath.style.animation = '';
+			for (const el of splashes) {
+				el.style.animation = '';
+			}
+		}
+
+		const observer = new IntersectionObserver(
+			(entries) => {
+				for (const entry of entries) {
+					if (!entry.isIntersecting) {
+						hasLeft = true;
+					} else if (hasLeft) {
+						hasLeft = false;
+						restartEnso();
+					}
+				}
+			},
+			{ threshold: 0.5 },
+		);
+
+		observer.observe(ensoWrapper);
+	}
 </script>

--- a/src/pages/heart-sutra.astro
+++ b/src/pages/heart-sutra.astro
@@ -29,15 +29,18 @@ import BackButton from '../components/BackButton.astro';
 					  Path is a near-circle with slight asymmetry (control points
 					  vary a few px) to mimic a hand-drawn brushstroke.
 					  The gap sits at the top (~11 o'clock) between the
-					  endpoint (84,18) and the startpoint (109,17).
+					  startpoint (84,18) and the endpoint (109,17).
+					  The stroke draws left-to-right: starting at the left edge
+					  of the gap, sweeping counter-clockwise through the bottom,
+					  and arriving at the right edge of the gap.
 					-->
 					<path
 						class="enso-circle"
-						d="M 109 17
-						   C 156 15, 186 55, 184 102
-						   C 182 149, 145 185, 97 184
-						   C 49 183, 14 145, 15 97
-						   C 16 51, 53 18, 84 18"
+						d="M 84 18
+						   C 53 18, 16 51, 15 97
+						   C 14 145, 49 183, 97 184
+						   C 145 185, 182 149, 184 102
+						   C 186 55, 156 15, 109 17"
 						fill="none"
 						stroke="currentColor"
 						stroke-width="26"

--- a/src/pages/heart-sutra.astro
+++ b/src/pages/heart-sutra.astro
@@ -15,39 +15,9 @@ import BackButton from '../components/BackButton.astro';
 		<section class="book-cover">
 			<a href="/" class="back-link" aria-label="Back to home">← back</a>
 
-			<!-- Enso Circle (animated brushstroke) -->
+			<!-- Enso Circle (static asset, pulsing) -->
 			<div class="enso-wrapper" aria-hidden="true">
-				<svg class="enso" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg" overflow="visible">
-					<defs>
-						<!-- Low baseFrequency = coarse bristle marks; high scale = bold ink distortion -->
-						<filter id="enso-ink" x="-30%" y="-30%" width="160%" height="160%" color-interpolation-filters="sRGB">
-							<feTurbulence type="fractalNoise" baseFrequency="0.04 0.13" numOctaves="5" seed="7" result="noise"/>
-							<feDisplacementMap in="SourceGraphic" in2="noise" scale="13" xChannelSelector="R" yChannelSelector="G"/>
-						</filter>
-					</defs>
-					<!--
-					  Path is a near-circle with slight asymmetry (control points
-					  vary a few px) to mimic a hand-drawn brushstroke.
-					  The gap sits at the top (~11 o'clock) between the
-					  startpoint (62,22) at ~10-o'clock and endpoint (138,22) at ~2-o'clock.
-					  Gap is 76 px wide (> stroke-width 40) so it stays open.
-					  Stroke draws left-to-right: sweeping counter-clockwise
-					  through the bottom and arriving at the right gap edge.
-					-->
-					<path
-						class="enso-circle"
-						d="M 62 22
-						   C 38 38, 16 51, 15 97
-						   C 14 145, 49 183, 97 184
-						   C 145 185, 182 149, 184 102
-						   C 186 55, 162 38, 138 22"
-						fill="none"
-						stroke="currentColor"
-						stroke-width="40"
-						stroke-linecap="round"
-						filter="url(#enso-ink)"
-					/>
-				</svg>
+				<img src="/enso.svg" class="enso" alt="" role="presentation">
 			</div>
 
 			<div class="cover-title">
@@ -498,7 +468,7 @@ import BackButton from '../components/BackButton.astro';
 		color: var(--ink);
 	}
 
-	/* enso SVG */
+	/* enso */
 	.enso-wrapper {
 		margin-bottom: 3rem;
 	}
@@ -506,57 +476,23 @@ import BackButton from '../components/BackButton.astro';
 	.enso {
 		width: var(--enso-size);
 		height: var(--enso-size);
-		color: var(--ink);
 		display: block;
+		animation: enso-pulse 5s ease-in-out infinite;
 	}
 
-	.enso-circle {
-		stroke-dasharray: 720;
-		stroke-dashoffset: 720;
-		opacity: 0;
-		animation:
-			enso-draw 15s linear infinite,
-			enso-fade 15s linear infinite;
+	/* Dark mode: invert the hardcoded #1c1917 stroke to near-white */
+	:global(.dark) .enso {
+		filter: invert(1);
 	}
 
-	/*
-	 * enso-draw  — controls the brushstroke reveal.
-	 *   0 – 22 %  : draw  (ease-out applied via animation-timing-function)
-	 *  22 – 78 %  : hold fully drawn
-	 *  78 – 78.5 %: snap reset while opacity = 0 (instant, invisible)
-	 *  78.5–100 % : pause before the next stroke begins
-	 */
-	@keyframes enso-draw {
-		0% {
-			stroke-dashoffset: 720;
-			animation-timing-function: cubic-bezier(0.2, 0, 0.4, 1);
-		}
-		22%   { stroke-dashoffset: 0; }
-		78%   { stroke-dashoffset: 0; }
-		78.5% { stroke-dashoffset: 720; }
-		100%  { stroke-dashoffset: 720; }
+	@keyframes enso-pulse {
+		0%, 100% { opacity: 0.7;  transform: scale(0.97); }
+		50%       { opacity: 1;   transform: scale(1);    }
 	}
 
-	/*
-	 * enso-fade  — controls visibility.
-	 *   0 –  2 %  : invisible (stroke hasn't started yet)
-	 *   2 – 66 %  : fade in quickly, then hold fully visible
-	 *  66 – 78 %  : dissolve out
-	 *  78 – 100 % : stay invisible while stroke resets
-	 */
-	@keyframes enso-fade {
-		0%   { opacity: 0; }
-		2%   { opacity: 1; }
-		66%  { opacity: 1; }
-		78%  { opacity: 0; }
-		100% { opacity: 0; }
-	}
-
-	/* Respect user's motion preferences — show circle statically */
 	@media (prefers-reduced-motion: reduce) {
-		.enso-circle {
+		.enso {
 			animation: none;
-			stroke-dashoffset: 0;
 			opacity: 1;
 		}
 	}

--- a/src/pages/heart-sutra.astro
+++ b/src/pages/heart-sutra.astro
@@ -18,17 +18,31 @@ import BackButton from '../components/BackButton.astro';
 			<!-- Enso Circle (animated brushstroke) -->
 			<div class="enso-wrapper" aria-hidden="true">
 				<svg class="enso" viewBox="0 0 200 200" xmlns="http://www.w3.org/2000/svg">
+					<defs>
+						<!-- Subtle displacement gives the stroke a bristle-like organic quality -->
+						<filter id="enso-ink" x="-6%" y="-6%" width="112%" height="112%" color-interpolation-filters="sRGB">
+							<feTurbulence type="fractalNoise" baseFrequency="0.72 0.38" numOctaves="4" seed="7" result="noise"/>
+							<feDisplacementMap in="SourceGraphic" in2="noise" scale="2.8" xChannelSelector="R" yChannelSelector="G"/>
+						</filter>
+					</defs>
+					<!--
+					  Path is a near-circle with slight asymmetry (control points
+					  vary a few px) to mimic a hand-drawn brushstroke.
+					  The gap sits at the top (~11 o'clock) between the
+					  endpoint (84,18) and the startpoint (109,17).
+					-->
 					<path
 						class="enso-circle"
-						d="M 100 22
-						   C 144 22, 178 57, 178 100
-						   C 178 143, 144 178, 100 178
-						   C 56 178, 22 143, 22 100
-						   C 22 60, 50 27, 94 22"
+						d="M 109 17
+						   C 156 15, 186 55, 184 102
+						   C 182 149, 145 185, 97 184
+						   C 49 183, 14 145, 15 97
+						   C 16 51, 53 18, 84 18"
 						fill="none"
 						stroke="currentColor"
-						stroke-width="9"
+						stroke-width="26"
 						stroke-linecap="round"
+						filter="url(#enso-ink)"
 					/>
 				</svg>
 			</div>
@@ -494,13 +508,54 @@ import BackButton from '../components/BackButton.astro';
 	}
 
 	.enso-circle {
-		stroke-dasharray: 680;
-		stroke-dashoffset: 680;
-		animation: draw-enso 2.6s cubic-bezier(0.4, 0, 0.2, 1) forwards 0.5s;
+		stroke-dasharray: 720;
+		stroke-dashoffset: 720;
+		opacity: 0;
+		animation:
+			enso-draw 15s linear infinite,
+			enso-fade 15s linear infinite;
 	}
 
-	@keyframes draw-enso {
-		to { stroke-dashoffset: 0; }
+	/*
+	 * enso-draw  — controls the brushstroke reveal.
+	 *   0 – 22 %  : draw  (ease-out applied via animation-timing-function)
+	 *  22 – 78 %  : hold fully drawn
+	 *  78 – 78.5 %: snap reset while opacity = 0 (instant, invisible)
+	 *  78.5–100 % : pause before the next stroke begins
+	 */
+	@keyframes enso-draw {
+		0% {
+			stroke-dashoffset: 720;
+			animation-timing-function: cubic-bezier(0.2, 0, 0.4, 1);
+		}
+		22%   { stroke-dashoffset: 0; }
+		78%   { stroke-dashoffset: 0; }
+		78.5% { stroke-dashoffset: 720; }
+		100%  { stroke-dashoffset: 720; }
+	}
+
+	/*
+	 * enso-fade  — controls visibility.
+	 *   0 –  2 %  : invisible (stroke hasn't started yet)
+	 *   2 – 66 %  : fade in quickly, then hold fully visible
+	 *  66 – 78 %  : dissolve out
+	 *  78 – 100 % : stay invisible while stroke resets
+	 */
+	@keyframes enso-fade {
+		0%   { opacity: 0; }
+		2%   { opacity: 1; }
+		66%  { opacity: 1; }
+		78%  { opacity: 0; }
+		100% { opacity: 0; }
+	}
+
+	/* Respect user's motion preferences — show circle statically */
+	@media (prefers-reduced-motion: reduce) {
+		.enso-circle {
+			animation: none;
+			stroke-dashoffset: 0;
+			opacity: 1;
+		}
 	}
 
 	/* cover typography */


### PR DESCRIPTION
## Summary
Added a new comprehensive page dedicated to the Heart Sutra (般若心経), featuring the complete sutra text in Japanese and English, along with detailed explanations of its core Buddhist teachings. The page is designed as a digital "bunkobon" (pocket book) with elegant typography and sumi-e illustrations.

## Key Changes
- **New page**: `src/pages/heart-sutra.astro` - A full-featured guide to the Heart Sutra with:
  - Animated enso (Zen circle) SVG on the cover
  - Complete Japanese sutra text with proper formatting
  - English translation of the sutra
  - Three detailed explanations covering:
    - Form and emptiness (色即是空)
    - The five aggregates (五蘊皆空)
    - The great mantra (羯諦羯諦...)
  - Sumi-e style illustrations (lotus flower and torii gate)
  - Back cover with descriptive blurb

- **Design features**:
  - Washi paper aesthetic with light/dark mode support
  - Responsive typography using CSS clamp()
  - Full-bleed layout that cancels parent padding
  - Subtle ruled-paper background pattern
  - Proper Japanese font stack with fallbacks
  - Accessible semantic HTML with proper lang attributes
  - Page numbers and chapter headers in traditional book style

- **Content structure**:
  - Title page with animated enso circle
  - Introduction explaining the sutra's significance
  - Japanese text with proper character spacing
  - English translation with romanized mantra
  - Three explanation sections with kanji, romaji, and detailed commentary
  - Back cover with book description

## Notable Implementation Details
- Uses CSS custom properties for theming (washi paper colors, ink tones)
- SVG illustrations are inline with proper accessibility attributes
- Mantra text preserved in original Sanskrit/Chinese characters
- Responsive design works from mobile to desktop
- Proper typography hierarchy using serif and sans-serif font families
- Explanation sections use numbered markers and visual separators

https://claude.ai/code/session_01DYUG6dSoFEjnC4pLHHmPRd